### PR TITLE
feat: TOML-tasks with per-task tools (v0.16.0)

### DIFF
--- a/.github/workflows/monorepo-root-proof.yml
+++ b/.github/workflows/monorepo-root-proof.yml
@@ -38,6 +38,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       MISE_EXPERIMENTAL: "1"
+      # Git Bash on Windows rewrites '//foo' → '/foo' (MSYS2 path translation)
+      # which mangles `//.shared:task` syntax. Disable the rewrite for this job.
+      # No-op on linux/macos.
+      MSYS_NO_PATHCONV: "1"
+      MSYS2_ARG_CONV_EXCL: "*"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/monorepo-root-proof.yml
+++ b/.github/workflows/monorepo-root-proof.yml
@@ -1,0 +1,153 @@
+name: monorepo-root proof
+
+# Cross-OS proof that mise's experimental_monorepo_root feature does what
+# we need for joeblew999 SSOT: a "shared" subdir's [tools] propagate
+# automatically when its tasks run, without the consumer's root mise.toml
+# pinning those tools itself.
+#
+# If this passes on linux + macos + windows, we can migrate consumer repos
+# (gsv, etc.) from `task_config.includes = ["git::..."]` to vendoring this
+# repo as a `.shared` subdir + `experimental_monorepo_root = true`.
+#
+# Background: jdx/mise discussion #4562 confirmed there's no native
+# cross-repo [tools] sharing. monorepo_root is the closest mise primitive,
+# but it's flagged experimental and the auto-discovery API was already
+# replaced once. This workflow is the gate before we depend on it org-wide.
+
+on:
+  push:
+    branches: [main, "feat/**"]
+    paths:
+      - "mise.toml"
+      - "mise-tasks/**"
+      - ".github/workflows/monorepo-root-proof.yml"
+  pull_request:
+    paths:
+      - "mise.toml"
+      - "mise-tasks/**"
+      - ".github/workflows/monorepo-root-proof.yml"
+  workflow_dispatch:
+
+jobs:
+  proof:
+    name: monorepo-root (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      MISE_EXPERIMENTAL: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mise
+        uses: jdx/mise-action@v4
+
+      # Build a synthetic consumer in $RUNNER_TEMP that vendors a fixture
+      # `.shared` subdir. We don't use this repo's real mise-tasks/ — we
+      # want to isolate the feature being tested (tool propagation through
+      # //path:task syntax) from any incidental task behavior.
+      - name: Construct synthetic consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${RUNNER_TEMP}/consumer"
+          rm -rf "$ROOT"
+          mkdir -p "$ROOT/.shared/mise-tasks" "$ROOT/mise-tasks"
+
+          # .shared pins jq + fnox (NOT in consumer root)
+          cat > "$ROOT/.shared/mise.toml" <<'EOF'
+          [tools]
+          "aqua:jqlang/jq"   = "1"
+          "github:jdx/fnox"  = "1.24"
+          EOF
+
+          # Shared task: requires jq + fnox. Will only succeed if monorepo
+          # tool inheritance puts them on PATH for this task's execution.
+          cat > "$ROOT/.shared/mise-tasks/needs-shared-tools" <<'EOF'
+          #!/usr/bin/env bash
+          #MISE description="prove jq + fnox from .shared/mise.toml propagated"
+          set -euo pipefail
+          command -v jq   >/dev/null || { echo "✗ jq not on PATH"; exit 1; }
+          command -v fnox >/dev/null || { echo "✗ fnox not on PATH"; exit 1; }
+          jq --version
+          fnox --version
+          echo "✓ shared task ran with .shared/mise.toml [tools] resolved"
+          EOF
+          chmod +x "$ROOT/.shared/mise-tasks/needs-shared-tools"
+
+          # Consumer root: pins ONLY nushell. NOT jq, NOT fnox. The point
+          # is to prove the consumer doesn't need to know what its
+          # adopted-from-shared tasks need.
+          cat > "$ROOT/mise.toml" <<'EOF'
+          experimental_monorepo_root = true
+
+          [monorepo]
+          config_roots = [".shared"]
+
+          [task_config]
+          includes = ["mise-tasks"]
+
+          [tools]
+          "github:nushell/nushell" = "0.112"
+          EOF
+
+          # Local task with cross-root depends. mise must:
+          #   1. discover the //.shared:needs-shared-tools task
+          #   2. install + activate jq+fnox before running it
+          #   3. then run this local task with consumer's own context
+          cat > "$ROOT/mise-tasks/proves-tools-flow" <<'EOF'
+          #!/usr/bin/env bash
+          #MISE description="local task with cross-root depends — tools must flow"
+          #MISE depends=["//.shared:needs-shared-tools"]
+          set -euo pipefail
+          echo "✓ local task ran after shared dependency completed"
+          EOF
+          chmod +x "$ROOT/mise-tasks/proves-tools-flow"
+
+          echo "→ fixture layout:"
+          find "$ROOT" -type f | sort
+
+      - name: Trust both configs
+        shell: bash
+        run: |
+          cd "${RUNNER_TEMP}/consumer"
+          mise trust
+          mise trust .shared
+
+      - name: Discovery — //.shared:needs-shared-tools must appear
+        shell: bash
+        working-directory: ${{ runner.temp }}/consumer
+        run: |
+          set -euo pipefail
+          mise tasks ls --all
+          mise tasks ls --all | grep -q "//\.shared:needs-shared-tools" \
+            || { echo "✗ shared task not discovered"; exit 1; }
+          echo "✓ shared task discovered via monorepo config_root"
+
+      - name: Direct invocation — //.shared:needs-shared-tools resolves jq+fnox
+        shell: bash
+        working-directory: ${{ runner.temp }}/consumer
+        run: mise run "//.shared:needs-shared-tools"
+
+      - name: Cross-root depends — proves-tools-flow pulls in shared task
+        shell: bash
+        working-directory: ${{ runner.temp }}/consumer
+        run: mise run proves-tools-flow
+
+      # Negative: confirm jq is NOT on the consumer's root PATH outside of
+      # a //.shared: task. This is the "tools stay scoped" promise — the
+      # consumer's own tasks shouldn't see .shared's tools leak in.
+      - name: Negative — jq is NOT on root context PATH
+        shell: bash
+        working-directory: ${{ runner.temp }}/consumer
+        run: |
+          set -euo pipefail
+          if mise current | grep -q "jqlang/jq"; then
+            echo "✗ unexpected: jq is in root context"
+            mise current
+            exit 1
+          fi
+          echo "✓ confirmed: .shared tools stay scoped, no leak to root"

--- a/.github/workflows/monorepo-root-proof.yml
+++ b/.github/workflows/monorepo-root-proof.yml
@@ -13,6 +13,9 @@ name: monorepo-root proof
 # cross-repo [tools] sharing. monorepo_root is the closest mise primitive,
 # but it's flagged experimental and the auto-discovery API was already
 # replaced once. This workflow is the gate before we depend on it org-wide.
+#
+# All `shell:` step bodies use nushell — joeblew999 SSOT policy is
+# "no bash anywhere", incl. CI step bodies.
 
 on:
   push:
@@ -38,11 +41,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       MISE_EXPERIMENTAL: "1"
-      # Git Bash on Windows rewrites '//foo' → '/foo' (MSYS2 path translation)
-      # which mangles `//.shared:task` syntax. Disable the rewrite for this job.
-      # No-op on linux/macos.
-      MSYS_NO_PATHCONV: "1"
-      MSYS2_ARG_CONV_EXCL: "*"
 
     steps:
       - uses: actions/checkout@v6
@@ -55,39 +53,43 @@ jobs:
       # want to isolate the feature being tested (tool propagation through
       # //path:task syntax) from any incidental task behavior.
       - name: Construct synthetic consumer
-        shell: bash
+        shell: 'mise exec -- nu --no-newline {0}'
         run: |
-          set -euo pipefail
-          ROOT="${RUNNER_TEMP}/consumer"
-          rm -rf "$ROOT"
-          mkdir -p "$ROOT/.shared/mise-tasks" "$ROOT/mise-tasks"
+          let root = ($env.RUNNER_TEMP | path join "consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir ($root | path join ".shared" "mise-tasks")
+          mkdir ($root | path join "mise-tasks")
 
           # .shared pins jq + fnox (NOT in consumer root)
-          cat > "$ROOT/.shared/mise.toml" <<'EOF'
-          [tools]
+          let shared_toml = '[tools]
           "aqua:jqlang/jq"   = "1"
           "github:jdx/fnox"  = "1.24"
-          EOF
+          '
+          $shared_toml | save --force ($root | path join ".shared" "mise.toml")
 
           # Shared task: requires jq + fnox. Will only succeed if monorepo
           # tool inheritance puts them on PATH for this task's execution.
-          cat > "$ROOT/.shared/mise-tasks/needs-shared-tools" <<'EOF'
-          #!/usr/bin/env bash
+          let shared_task = '#!/usr/bin/env nu
           #MISE description="prove jq + fnox from .shared/mise.toml propagated"
-          set -euo pipefail
-          command -v jq   >/dev/null || { echo "✗ jq not on PATH"; exit 1; }
-          command -v fnox >/dev/null || { echo "✗ fnox not on PATH"; exit 1; }
-          jq --version
-          fnox --version
-          echo "✓ shared task ran with .shared/mise.toml [tools] resolved"
-          EOF
-          chmod +x "$ROOT/.shared/mise-tasks/needs-shared-tools"
+          if (which jq | is-empty) { print --stderr "✗ jq not on PATH"; exit 1 }
+          if (which fnox | is-empty) { print --stderr "✗ fnox not on PATH"; exit 1 }
+          ^jq --version
+          ^fnox --version
+          print "✓ shared task ran with .shared/mise.toml [tools] resolved"
+          '
+          let shared_task_path = ($root | path join ".shared" "mise-tasks" "needs-shared-tools")
+          $shared_task | save --force $shared_task_path
+          chmod +x $shared_task_path
 
           # Consumer root: pins ONLY nushell. NOT jq, NOT fnox. The point
           # is to prove the consumer doesn't need to know what its
           # adopted-from-shared tasks need.
-          cat > "$ROOT/mise.toml" <<'EOF'
-          experimental_monorepo_root = true
+          # lockfile = true is mise default since 2026; explicit here for
+          # consumers who reverted it. Combined with monorepo_root, the
+          # consumer's mise.lock will pin resolved versions of .shared's
+          # tools deterministically.
+          let root_toml = 'experimental_monorepo_root = true
+          lockfile = true
 
           [monorepo]
           config_roots = [".shared"]
@@ -97,62 +99,70 @@ jobs:
 
           [tools]
           "github:nushell/nushell" = "0.112"
-          EOF
+          '
+          $root_toml | save --force ($root | path join "mise.toml")
 
           # Local task with cross-root depends. mise must:
           #   1. discover the //.shared:needs-shared-tools task
           #   2. install + activate jq+fnox before running it
           #   3. then run this local task with consumer's own context
-          cat > "$ROOT/mise-tasks/proves-tools-flow" <<'EOF'
-          #!/usr/bin/env bash
+          let local_task = '#!/usr/bin/env nu
           #MISE description="local task with cross-root depends — tools must flow"
           #MISE depends=["//.shared:needs-shared-tools"]
-          set -euo pipefail
-          echo "✓ local task ran after shared dependency completed"
-          EOF
-          chmod +x "$ROOT/mise-tasks/proves-tools-flow"
+          print "✓ local task ran after shared dependency completed"
+          '
+          let local_task_path = ($root | path join "mise-tasks" "proves-tools-flow")
+          $local_task | save --force $local_task_path
+          chmod +x $local_task_path
 
-          echo "→ fixture layout:"
-          find "$ROOT" -type f | sort
+          print "→ fixture layout:"
+          ls -al $root
+          ls -al ($root | path join ".shared")
+          ls -al ($root | path join ".shared" "mise-tasks")
+          ls -al ($root | path join "mise-tasks")
 
       - name: Trust both configs
-        shell: bash
+        shell: 'mise exec -- nu --no-newline {0}'
         run: |
-          cd "${RUNNER_TEMP}/consumer"
-          mise trust
-          mise trust .shared
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise trust
+          ^mise trust .shared
 
       - name: Discovery — //.shared:needs-shared-tools must appear
-        shell: bash
-        working-directory: ${{ runner.temp }}/consumer
+        shell: 'mise exec -- nu --no-newline {0}'
         run: |
-          set -euo pipefail
-          mise tasks ls --all
-          mise tasks ls --all | grep -q "//\.shared:needs-shared-tools" \
-            || { echo "✗ shared task not discovered"; exit 1; }
-          echo "✓ shared task discovered via monorepo config_root"
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          let listing = (^mise tasks ls --all | complete)
+          print $listing.stdout
+          if not ($listing.stdout | str contains "//.shared:needs-shared-tools") {
+            print --stderr "✗ shared task not discovered"
+            exit 1
+          }
+          print "✓ shared task discovered via monorepo config_root"
 
       - name: Direct invocation — //.shared:needs-shared-tools resolves jq+fnox
-        shell: bash
-        working-directory: ${{ runner.temp }}/consumer
-        run: mise run "//.shared:needs-shared-tools"
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise run "//.shared:needs-shared-tools"
 
       - name: Cross-root depends — proves-tools-flow pulls in shared task
-        shell: bash
-        working-directory: ${{ runner.temp }}/consumer
-        run: mise run proves-tools-flow
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise run proves-tools-flow
 
       # Negative: confirm jq is NOT on the consumer's root PATH outside of
       # a //.shared: task. This is the "tools stay scoped" promise — the
       # consumer's own tasks shouldn't see .shared's tools leak in.
       - name: Negative — jq is NOT on root context PATH
-        shell: bash
-        working-directory: ${{ runner.temp }}/consumer
+        shell: 'mise exec -- nu --no-newline {0}'
         run: |
-          set -euo pipefail
-          if mise current | grep -q "jqlang/jq"; then
-            echo "✗ unexpected: jq is in root context"
-            mise current
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          let current = (^mise current | complete)
+          if ($current.stdout | str contains "jqlang/jq") {
+            print --stderr "✗ unexpected: jq is in root context"
+            print $current.stdout
             exit 1
-          fi
-          echo "✓ confirmed: .shared tools stay scoped, no leak to root"
+          }
+          print "✓ confirmed: .shared tools stay scoped, no leak to root"

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -252,3 +252,76 @@ jobs:
             exit 1
           }
           print "✓ ci:clean failed cleanly with 'no GitHub token'"
+
+      # ── Real-file validation: cf.toml + secrets.toml ────────────────────
+      # Same pattern as ci.toml. Construct a consumer that includes ALL
+      # three real files, verify discovery + negative paths.
+      - name: Real cf.toml + secrets.toml — construct consumer, trust, discover
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "multi-consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+
+          let ci_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "ci.toml")
+          let cf_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "cf.toml")
+          let secrets_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "secrets.toml")
+
+          let root_toml = $"[task_config]
+          includes = ['($ci_toml)', '($cf_toml)', '($secrets_toml)']
+
+          [tools]
+          \"github:nushell/nushell\" = \"0.112\"
+          "
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          cd $root
+          ^mise trust
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          for t in ["ci:parse-check", "cf:token-check", "secrets:sync-github"] {
+            if not ($listing.stdout | str contains $t) {
+              print --stderr $"✗ ($t) not discovered"
+              exit 1
+            }
+          }
+          print "✓ ci:* + cf:* + secrets:* tasks all discovered together"
+
+      - name: Real cf.toml — cf:token-check fails cleanly with no token
+        shell: 'mise exec -- nu --no-newline {0}'
+        env:
+          CLOUDFLARE_API_TOKEN: ""
+        run: |
+          cd ($env.RUNNER_TEMP | path join "multi-consumer")
+          let r = (^mise run "cf:token-check" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ cf:token-check should have failed with no token"
+            exit 1
+          }
+          if not (($r.stdout + $r.stderr) | str contains "not set and not in fnox") {
+            print --stderr $"✗ wrong error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ cf:token-check failed cleanly"
+
+      - name: Real secrets.toml — secrets:sync-github fails cleanly with no FNOX_SYNC_KEYS
+        shell: 'mise exec -- nu --no-newline {0}'
+        env:
+          FNOX_SYNC_KEYS: ""
+        run: |
+          cd ($env.RUNNER_TEMP | path join "multi-consumer")
+          # secrets:sync-github needs a git remote, but this fixture isn't a
+          # repo — it'll fail at the origin-remote check FIRST. That's still
+          # a clean negative path; assert exit≠0 + a recognisable message.
+          let r = (^mise run "secrets:sync-github" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ secrets:sync-github should have failed"
+            exit 1
+          }
+          let combined = ($r.stdout + $r.stderr)
+          let acceptable = (($combined | str contains "FNOX_SYNC_KEYS not set") or ($combined | str contains "no git origin remote"))
+          if not $acceptable {
+            print --stderr $"✗ unexpected error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ secrets:sync-github failed cleanly"

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -1,0 +1,156 @@
+name: tasks-toml proof
+
+# Cross-OS proof for the chosen SSOT mechanism: TOML-task definitions
+# with per-task `tools = { ... }` blocks, included via task_config.includes
+# from a git remote.
+#
+# What this validates:
+#   - mise's task_config.includes can point at a .toml file (not just a dir
+#     of executable file-tasks)
+#   - That .toml file can declare multiple namespaced tasks via [<ns>:<name>]
+#     blocks (TOML-task syntax)
+#   - Each task can declare its own `tools = { ... }` — those tools are
+#     auto-installed when the task runs
+#   - The mechanism works through remote git includes (?ref=<tag>)
+#   - Tools stay scoped to the task — they don't leak into root context
+#
+# Why this matters: this is mise's only stable (non-experimental) way to
+# share both tasks AND their tool requirements across repos. It replaces
+# the per-namespace `<ns>:install-tools` workaround we considered earlier,
+# and is dramatically simpler than vendoring + experimental_monorepo_root.
+#
+# Background: discussion #5267 says remote *file tasks* (executables with
+# `#MISE tools=` headers) don't propagate tools — confirmed empirically.
+# But TOML tasks with structured `tools = {}` fields go through a different
+# code path and DO propagate. This workflow is the regression canary.
+
+on:
+  push:
+    branches: [main, "feat/**"]
+    paths:
+      - "tasks/**"
+      - ".github/workflows/tasks-toml-proof.yml"
+  pull_request:
+    paths:
+      - "tasks/**"
+      - ".github/workflows/tasks-toml-proof.yml"
+  workflow_dispatch:
+
+jobs:
+  proof:
+    name: tasks-toml (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mise
+        uses: jdx/mise-action@v4
+
+      # Build a synthetic consumer in $RUNNER_TEMP that includes a fixture
+      # tasks.toml file (simulating a remote git include with a local path —
+      # the per-task tools propagation works the same way either way; the
+      # path is just different).
+      - name: Construct synthetic consumer with fixture tasks.toml
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+          mkdir ($root | path join "shared-fixture")
+
+          # The shared "remote" tasks.toml — declares two namespaced tasks
+          # each with their own per-task tools = { ... } block.
+          let shared_toml = '["bw:list-mock"]
+          description = "Mock bw:list with per-task tools"
+          tools = { "aqua:jqlang/jq" = "1", "github:jdx/fnox" = "1.24" }
+          run = """
+          echo \"→ bw:list-mock\"
+          which jq && jq --version
+          which fnox && fnox --version
+          """
+
+          ["cf:check-mock"]
+          description = "Mock cf:check with per-task tools"
+          tools = { "aqua:cli/cli" = "2" }
+          run = """
+          echo \"→ cf:check-mock\"
+          which gh && gh --version | head -1
+          """
+          '
+          $shared_toml | save --force ($root | path join "shared-fixture" "tasks.toml")
+
+          # Consumer root: pins ONLY nushell. NOT jq, NOT fnox, NOT gh.
+          # Per-task tools must be picked up automatically from the included
+          # tasks.toml — that is the entire premise.
+          let root_toml = 'lockfile = true
+
+          [task_config]
+          includes = ["shared-fixture/tasks.toml"]
+
+          [tools]
+          "github:nushell/nushell" = "0.112"
+          '
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          print "→ fixture layout:"
+          ls -al $root
+          ls -al ($root | path join "shared-fixture")
+
+      - name: Trust config
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise trust
+
+      - name: Discovery — both namespaced TOML tasks must appear
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          if not ($listing.stdout | str contains "bw:list-mock") {
+            print --stderr "✗ bw:list-mock not discovered"
+            exit 1
+          }
+          if not ($listing.stdout | str contains "cf:check-mock") {
+            print --stderr "✗ cf:check-mock not discovered"
+            exit 1
+          }
+          print "✓ both TOML-tasks discovered through task_config.includes"
+
+      - name: Run bw:list-mock — per-task tools (jq + fnox) must auto-install
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise run "bw:list-mock"
+
+      - name: Run cf:check-mock — different per-task tools (gh) must auto-install
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          ^mise run "cf:check-mock"
+
+      # Negative: confirm per-task tools stay scoped — they should NOT show up
+      # in the consumer's root tool context. This is the "tools propagate WITH
+      # the task, not OUT of it" promise.
+      - name: Negative — jq/fnox/gh are NOT in root context
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "consumer")
+          let current = (^mise current | complete)
+          let leaked = (
+            ($current.stdout | str contains "jqlang/jq")
+            or ($current.stdout | str contains "jdx/fnox")
+            or ($current.stdout | str contains "cli/cli")
+          )
+          if $leaked {
+            print --stderr "✗ unexpected: per-task tool leaked into root context"
+            print $current.stdout
+            exit 1
+          }
+          print "✓ confirmed: per-task tools stay scoped to their task"

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -169,11 +169,15 @@ jobs:
           mkdir $root
           mkdir ($root | path join "mise-tasks")
 
-          # Use the checked-out repo's tasks/ci.toml directly via absolute path
+          # Use the checked-out repo's tasks/ci.toml directly via absolute path.
+          # On Windows, GITHUB_WORKSPACE has backslashes which break TOML
+          # double-quoted strings (treated as escape sequences). Wrap in TOML
+          # *literal* strings (single quotes) — no escape processing — so
+          # backslash paths pass through verbatim.
           let ci_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "ci.toml")
 
           let root_toml = $"[task_config]
-          includes = [\"($ci_toml)\"]
+          includes = ['($ci_toml)']
 
           [tools]
           \"github:nushell/nushell\" = \"0.112\"

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -154,3 +154,97 @@ jobs:
             exit 1
           }
           print "✓ confirmed: per-task tools stay scoped to their task"
+
+      # ── Real-file validation ────────────────────────────────────────────
+      # The synthetic fixture above proves the mechanism. This second section
+      # proves the REAL tasks/*.toml files we ship to consumers actually load,
+      # discover their tasks, and the negative paths still fire correctly
+      # (no token / no git repo). Catches breakage if a future edit to a
+      # real tasks/<ns>.toml introduces a syntax error or wrong tool pin.
+      - name: Real tasks/ci.toml — construct consumer that includes it
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "real-consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+          mkdir ($root | path join "mise-tasks")
+
+          # Use the checked-out repo's tasks/ci.toml directly via absolute path
+          let ci_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "ci.toml")
+
+          let root_toml = $"[task_config]
+          includes = [\"($ci_toml)\"]
+
+          [tools]
+          \"github:nushell/nushell\" = \"0.112\"
+          "
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          # Add a sample nu task so ci:parse-check has something to chew on
+          let sample = '#!/usr/bin/env nu
+          #MISE description="sample nu task"
+          print "hello"
+          '
+          $sample | save --force ($root | path join "mise-tasks" "sample")
+          chmod +x ($root | path join "mise-tasks" "sample")
+
+      - name: Real tasks/ci.toml — trust + discovery
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "real-consumer")
+          ^mise trust
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          for t in ["ci:parse-check", "ci:watch", "ci:clean"] {
+            if not ($listing.stdout | str contains $t) {
+              print --stderr $"✗ ($t) not discovered from real tasks/ci.toml"
+              exit 1
+            }
+          }
+          print "✓ all three ci:* tasks discovered from real tasks/ci.toml"
+
+      - name: Real tasks/ci.toml — ci:parse-check runs cleanly
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          cd ($env.RUNNER_TEMP | path join "real-consumer")
+          ^mise run "ci:parse-check"
+
+      # Negative: ci:watch + ci:clean must fail with "no GitHub token" when
+      # run with empty env. Locks the contract consumers' CI relies on.
+      - name: Real tasks/ci.toml — ci:watch fails cleanly with no token
+        shell: 'mise exec -- nu --no-newline {0}'
+        env:
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
+          MISE_GITHUB_TOKEN: ""
+        run: |
+          cd ($env.RUNNER_TEMP | path join "real-consumer")
+          let r = (^mise run "ci:watch" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ ci:watch should have failed with no token"
+            exit 1
+          }
+          if not (($r.stdout + $r.stderr) | str contains "no GitHub token") {
+            print --stderr $"✗ wrong error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ ci:watch failed cleanly with 'no GitHub token'"
+
+      - name: Real tasks/ci.toml — ci:clean fails cleanly with no token
+        shell: 'mise exec -- nu --no-newline {0}'
+        env:
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
+          MISE_GITHUB_TOKEN: ""
+        run: |
+          cd ($env.RUNNER_TEMP | path join "real-consumer")
+          let r = (^mise run "ci:clean" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ ci:clean should have failed with no token"
+            exit 1
+          }
+          if not (($r.stdout + $r.stderr) | str contains "no GitHub token") {
+            print --stderr $"✗ wrong error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ ci:clean failed cleanly with 'no GitHub token'"

--- a/tasks/cf.toml
+++ b/tasks/cf.toml
@@ -1,0 +1,46 @@
+# tasks/cf.toml — TOML-task definitions for the cf:* (Cloudflare) namespace.
+#
+# See tasks/ci.toml for the consumer wiring + tool pin policy.
+
+# ── cf:token-check ───────────────────────────────────────────────────────────
+# Verify CLOUDFLARE_API_TOKEN is valid — reads from env or fnox, calls the
+# Cloudflare /user/tokens/verify endpoint, prints token id+status on success.
+# Used by deploy/prove tasks as a precondition gate.
+["cf:token-check"]
+description = "verify CLOUDFLARE_API_TOKEN is valid — reads from env or fnox"
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let token = (
+    if ($env.CLOUDFLARE_API_TOKEN? | default "" | is-not-empty) {
+      $env.CLOUDFLARE_API_TOKEN
+    } else {
+      try { ^fnox get CLOUDFLARE_API_TOKEN | str trim } catch { "" }
+    }
+  )
+  if ($token | is-empty) {
+    print --stderr "✗ CLOUDFLARE_API_TOKEN not set and not in fnox"
+    exit 1
+  }
+
+  let result = (
+    try {
+      ^curl -sS -H $"Authorization: Bearer ($token)" "https://api.cloudflare.com/client/v4/user/tokens/verify" | from json
+    } catch {
+      {success: false}
+    }
+  )
+
+  if ($result.success? | default false) {
+    let status = ($result.result.status? | default "?")
+    let id = ($result.result.id? | default "?")
+    print $"✓ token valid \(id=($id) status=($status)\)"
+  } else {
+    print "✗ token invalid or expired"
+    print ($result | to json)
+    exit 1
+  }
+}
+'''

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -1,0 +1,374 @@
+# tasks/ci.toml — TOML-task definitions for the ci:* namespace.
+#
+# Each task declares its own `tools = { ... }` — those tools auto-install
+# when the task runs and don't leak into the consumer's root context.
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/ci.toml?ref=v0.16.0",
+#   ]
+#
+# No experimental flag, no vendoring, no env-var setup needed. Validated by
+# .github/workflows/tasks-toml-proof.yml on linux+macos+windows.
+#
+# Tool pin policy: track the same versions as joeblew999/.github's own
+# mise.toml [tools] block. Bump them together when the lib version is bumped.
+
+# ── ci:parse-check ───────────────────────────────────────────────────────────
+# Generic parse-checker for nu task files. Globs the consumer's mise-tasks/
+# (recursive), filters to files whose first line is the nu shebang, runs
+# `nu --ide-check 1` on each. Used by every consumer's local `check` bundle
+# as the cheap first-line-of-defense lint.
+["ci:parse-check"]
+description = "Parse-check every nu task file in mise-tasks/ (fails if any has a syntax error)"
+tools = { "github:nushell/nushell" = "0.112" }
+run = '''
+#!/usr/bin/env nu
+
+def main [
+  --dir (-d): string = "mise-tasks"   # directory to scan; default: mise-tasks
+] {
+  let project_root = ($env.MISE_PROJECT_ROOT? | default (pwd))
+  cd $project_root
+
+  if not ($dir | path exists) {
+    print $"\(no ($dir)/ in this repo — nothing to check)"
+    return
+  }
+
+  let files = (
+    glob $"($dir)/**/*"
+    | where { |p| ($p | path type) == "file" }
+    | where { |p|
+        let first = (try { open --raw $p | lines | first } catch { "" })
+        $first == "#!/usr/bin/env nu"
+      }
+  )
+
+  if ($files | length) == 0 {
+    print $"\(no nu task files found under ($dir)/)"
+    return
+  }
+
+  mut errors = []
+  for f in $files {
+    let result = (do { ^nu --ide-check 1 $f } | complete)
+    if ($result.stdout | str contains 'severity":"Error"') {
+      $errors = ($errors | append $f)
+      print --stderr $"✗ ($f | path basename)"
+      print --stderr ($result.stdout | lines | where { |l| ($l | str contains 'severity":"Error"') } | first)
+    }
+  }
+  if ($errors | length) > 0 {
+    print --stderr $"\n✗ ($errors | length) file\(s\) with parse errors"
+    exit 1
+  }
+  print $"✓ ($files | length) nu task files parse-clean"
+}
+'''
+
+# ── ci:watch ─────────────────────────────────────────────────────────────────
+# Polls GitHub Actions for the latest run on this branch, prints transitions
+# only, dumps failed-step logs as soon as a job completes (works mid-run).
+# REPO is auto-derived from `git remote get-url origin`; works in any repo.
+# Token from GH_TOKEN/GITHUB_TOKEN env or `fnox get GITHUB_TOKEN`.
+["ci:watch"]
+description = "Watch the latest CI run on this branch — streams per-job + per-step transitions, dumps failed-step logs via gh api"
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+run = '''
+#!/usr/bin/env nu
+
+def gh-token [] {
+  let env_tok = ($env.GH_TOKEN? | default ($env.GITHUB_TOKEN? | default ""))
+  if ($env_tok | is-not-empty) { return $env_tok }
+  try { ^fnox get GITHUB_TOKEN | str trim } catch { "" }
+}
+
+def origin-repo [] {
+  let url = (try { ^git remote get-url origin | str trim } catch { "" })
+  let parsed = ($url | parse --regex '.*[:/](?<owner>[^/]+)/(?<name>[^/]+?)(?:\.git)?$')
+  if ($parsed | length) == 0 { return "" }
+  let row = ($parsed | first)
+  $"($row.owner)/($row.name)"
+}
+
+def gh-run-view-retry [id: int, repo: string, token: string] {
+  mut attempts = 0
+  loop {
+    let r = (with-env {GH_TOKEN: $token} { do { ^gh run view $id --repo $repo --json status,conclusion,jobs } | complete })
+    if $r.exit_code == 0 { return ($r.stdout | from json) }
+    $attempts = $attempts + 1
+    if $attempts >= 5 {
+      print --stderr $"✗ gh api failed after 5 attempts: ($r.stderr | default '?' | str trim)"
+      exit 1
+    }
+    print $"  · gh api blip \(attempt ($attempts)/5\), retrying in 10s..."
+    sleep 10sec
+  }
+}
+
+def status-mark [status: string, conclusion: string] {
+  if $conclusion == "success" { "✓" }
+  else if $conclusion == "failure" { "✗" }
+  else if $conclusion == "cancelled" { "⊘" }
+  else if $conclusion == "skipped" { "·" }
+  else if $status == "in_progress" { "▶" }
+  else { "·" }
+}
+
+def job-duration [j: any, now: datetime] {
+  let started = ($j.startedAt? | default "")
+  if ($started | is-empty) { return "—" }
+  let s = ($started | into datetime)
+  let end = if ($j.status == "completed") {
+    ($j.completedAt? | default "" | into datetime)
+  } else { $now }
+  ($end - $s) | format duration sec
+}
+
+def step-duration [s: any, now: datetime] {
+  let started = ($s.startedAt? | default "")
+  if ($started | is-empty) { return "—" }
+  let st = ($started | into datetime)
+  let end = if ($s.status == "completed") {
+    ($s.completedAt? | default "" | into datetime)
+  } else { $now }
+  ($end - $st) | format duration sec
+}
+
+def main [
+  --run-id (-r): int          # specific run id (default: latest on --branch)
+  --branch (-b): string       # default: current branch from `git branch --show-current`
+  --workflow (-w): string = "mise.yml"
+  --interval (-i): int = 20    # seconds between polls
+] {
+  let token = (gh-token)
+  if ($token | is-empty) {
+    print --stderr "✗ no GitHub token: set GH_TOKEN, GITHUB_TOKEN, or fnox set GITHUB_TOKEN"
+    exit 1
+  }
+
+  let repo = (origin-repo)
+  if ($repo | is-empty) {
+    print --stderr "✗ couldn't parse repo from `git remote get-url origin`"
+    exit 1
+  }
+
+  let br = if $branch != null {
+    $branch
+  } else {
+    try { ^git branch --show-current | str trim } catch { "main" }
+  }
+
+  let id = if $run_id != null {
+    $run_id
+  } else {
+    let latest = (with-env {GH_TOKEN: $token} { ^gh run list --workflow $workflow --branch $br --limit 1 --repo $repo --json databaseId } | from json)
+    if ($latest | length) == 0 {
+      print --stderr $"✗ no runs found for ($workflow) on ($br) in ($repo)"
+      exit 1
+    }
+    ($latest | first | get databaseId)
+  }
+
+  let started = (date now)
+  print $"watching run ($id) on ($repo)  \(started ($started | format date '%H:%M:%S')\)"
+  mut seen = {}
+  mut failed_jobs = []
+
+  loop {
+    let detail = (gh-run-view-retry $id $repo $token)
+    let run_status = $detail.status
+    let run_conclusion = ($detail.conclusion | default "")
+    let now = (date now)
+
+    for j in $detail.jobs {
+      let job_id = ($j.databaseId | into string)
+      let job_cur = $"($j.status):($j.conclusion | default '')"
+      let job_prev = ($seen | get --optional $job_id | default "")
+      if $job_cur != $job_prev {
+        let mark = (status-mark $j.status ($j.conclusion | default ""))
+        let dur = (job-duration $j $now)
+        print $"  ($mark) ($j.name | fill -w 30 -a l) ($job_cur | fill -w 22 -a l) ($dur)"
+        $seen = ($seen | upsert $job_id $job_cur)
+        if $j.conclusion == "failure" and not ($job_id in $failed_jobs) {
+          $failed_jobs = ($failed_jobs | append $job_id)
+        }
+      }
+
+      for s in ($j.steps | default []) {
+        let key = $"($job_id):($s.number)"
+        let s_cur = $"($s.status):($s.conclusion | default '')"
+        let s_prev = ($seen | get --optional $key | default "")
+        if $s_cur != $s_prev {
+          let is_failure = ($s.conclusion == "failure")
+          let is_meaningful = (not (($s.name | str starts-with "Set up") or ($s.name | str starts-with "Post ") or ($s.name | str starts-with "Complete job") or ($s.name == "Pre run") or ($s.name == "Run actions/checkout@v5")))
+          if $is_failure or ($is_meaningful and ($s.conclusion != null and $s.conclusion != "")) {
+            let mark = (status-mark $s.status ($s.conclusion | default ""))
+            let dur = (step-duration $s $now)
+            print $"      ($mark) ($s.name | fill -w 36 -a l) ($s_cur | fill -w 22 -a l) ($dur)  [($j.name)]"
+          }
+          $seen = ($seen | upsert $key $s_cur)
+        }
+      }
+    }
+
+    if $run_status == "completed" {
+      let total = (((date now) - $started) | format duration sec)
+      print ""
+      print $"run ($id) → ($run_conclusion)  \(watcher ran ($total)\)"
+      break
+    }
+
+    let in_prog = ($detail.jobs | where { |j| $j.status == "in_progress" })
+    if ($in_prog | length) > 0 {
+      let elapsed = ((($now - $started) | format duration sec))
+      let summary = ($in_prog | each { |j| $"($j.name) [(job-duration $j $now)]" } | str join "  ")
+      print $"  · \(elapsed ($elapsed)\) running: ($summary)"
+    }
+
+    sleep ($interval * 1sec)
+  }
+
+  if ($failed_jobs | length) > 0 {
+    print ""
+    print "=== failed-job logs ==="
+    for jid in $failed_jobs {
+      print ""
+      print $"--- job ($jid) ---"
+      let log = (with-env {GH_TOKEN: $token} { do { ^gh api $"repos/($repo)/actions/jobs/($jid)/logs" } | complete })
+      let body = ($log.stdout | default "")
+      let lines = ($body | lines)
+      let markers = [
+        "task failed"
+        "Error: nu::"
+        "TypeError"
+        "AssertionError"
+        "##[error]"
+        "FAIL "
+        "error TS"
+        "error: "
+        "ERROR ["
+      ]
+      let hits = (
+        $lines
+        | enumerate
+        | where { |row| $markers | any { |m| ($row.item | str contains $m) } }
+        | get index
+      )
+      if ($hits | length) > 0 {
+        let printed = ($hits | each { |i|
+          let lo = if $i > 5 { $i - 5 } else { 0 }
+          let hi = if ($i + 3) < ($lines | length) { $i + 3 } else { ($lines | length) - 1 }
+          $lines | range $lo..$hi | str join "\n"
+        })
+        print ($printed | str join "\n  ---\n")
+      } else {
+        print "(no clear error markers; tail 40)"
+        print ($lines | last 40 | str join "\n")
+      }
+    }
+    exit 1
+  }
+}
+'''
+
+# ── ci:clean ─────────────────────────────────────────────────────────────────
+# Delete CI runs (default: failed/cancelled only; --all to nuke every run;
+# --dry-run to preview). REPO from origin remote; token from env/fnox.
+["ci:clean"]
+description = "Delete CI runs (default: failed/cancelled only; --all to nuke every run; --dry-run to preview)"
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+run = '''
+#!/usr/bin/env nu
+
+def gh-token [] {
+  let env_tok = ($env.GH_TOKEN? | default ($env.GITHUB_TOKEN? | default ""))
+  if ($env_tok | is-not-empty) { return $env_tok }
+  try { ^fnox get GITHUB_TOKEN | str trim } catch { "" }
+}
+
+def origin-repo [] {
+  let url = (try { ^git remote get-url origin | str trim } catch { "" })
+  let parsed = ($url | parse --regex '.*[:/](?<owner>[^/]+)/(?<name>[^/]+?)(?:\.git)?$')
+  if ($parsed | length) == 0 { return "" }
+  let row = ($parsed | first)
+  $"($row.owner)/($row.name)"
+}
+
+def main [
+  --all                      # delete every run, including successes
+  --branch (-b): string      # only this branch (default: any)
+  --workflow (-w): string = "mise.yml"
+  --limit (-l): int = 200    # max runs to consider per call
+  --keep-latest              # keep the latest successful run per branch
+  --dry-run                  # list candidates without deleting
+] {
+  let token = (gh-token)
+  if ($token | is-empty) {
+    print --stderr "✗ no GitHub token: set GH_TOKEN, GITHUB_TOKEN, or fnox set GITHUB_TOKEN"
+    exit 1
+  }
+  let repo = (origin-repo)
+  if ($repo | is-empty) {
+    print --stderr "✗ couldn't parse repo from `git remote get-url origin`"
+    exit 1
+  }
+
+  let base_args = ["run" "list" "--workflow" $workflow "--limit" ($limit | into string) "--repo" $repo "--json" "databaseId,conclusion,status,headBranch,createdAt"]
+  let args = if $branch != null { $base_args | append ["--branch" $branch] } else { $base_args }
+  let runs = (with-env {GH_TOKEN: $token} { ^gh ...$args } | from json)
+  if ($runs | length) == 0 {
+    print "no runs found"
+    return
+  }
+
+  let candidates = if $all {
+    if $keep_latest {
+      let keepers = (
+        $runs
+        | where conclusion == "success"
+        | sort-by createdAt -r
+        | group-by headBranch
+        | values
+        | each { |g| $g | first | get databaseId }
+      )
+      $runs | where { |r| not ($r.databaseId in $keepers) }
+    } else {
+      $runs
+    }
+  } else {
+    $runs | where { |r| $r.conclusion == "failure" or $r.conclusion == "cancelled" or $r.status != "completed" }
+  }
+
+  if ($candidates | length) == 0 {
+    print "✓ nothing to delete"
+    return
+  }
+
+  print $"target: ($workflow) on ($repo)"
+  print $"found ($candidates | length) run\(s\) to delete:"
+  for r in $candidates {
+    print $"  ($r.databaseId)  ($r.headBranch)  ($r.status):($r.conclusion | default '')"
+  }
+
+  if $dry_run {
+    print ""
+    print "(dry-run — no deletes)"
+    return
+  }
+
+  print ""
+  for r in $candidates {
+    let res = (with-env {GH_TOKEN: $token} { do { ^gh run delete ($r.databaseId | into string) --repo $repo } | complete })
+    if $res.exit_code == 0 {
+      print $"✓ deleted ($r.databaseId)"
+    } else {
+      print --stderr $"✗ failed to delete ($r.databaseId): ($res.stderr | default $res.stdout)"
+    }
+  }
+  print ""
+  print $"done — deleted ($candidates | length) run\(s\)"
+}
+'''

--- a/tasks/secrets.toml
+++ b/tasks/secrets.toml
@@ -1,0 +1,74 @@
+# tasks/secrets.toml — TOML-task definitions for the secrets:* namespace.
+#
+# See tasks/ci.toml for the consumer wiring + tool pin policy.
+
+# ── secrets:sync-github ──────────────────────────────────────────────────────
+# Push secrets from fnox → current repo's GitHub Actions secrets. Reads
+# FNOX_SYNC_KEYS from the consumer's mise.toml [env] (comma-separated).
+# Each named key is pulled from fnox and pushed via `gh secret set`.
+["secrets:sync-github"]
+description = "push secrets from fnox → current repo's GitHub Actions secrets"
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+run = '''
+#!/usr/bin/env nu
+
+def main [--dry-run] {
+  let dry = $dry_run
+
+  let origin_url = (try { ^git remote get-url origin | str trim } catch { "" })
+  if ($origin_url | is-empty) {
+    print --stderr "✗ no git origin remote — run from inside a git repo with a GitHub origin"
+    exit 1
+  }
+  let parsed = ($origin_url | parse --regex '.*[:/]([^/]+)/([^/]+?)(?:\.git)?$')
+  if ($parsed | length) == 0 {
+    print --stderr $"✗ couldn't parse owner/repo from origin URL: ($origin_url)"
+    exit 1
+  }
+  let repo = $"($parsed.capture0.0)/($parsed.capture1.0)"
+
+  let keys_str = ($env.FNOX_SYNC_KEYS? | default "")
+  if ($keys_str | is-empty) {
+    print --stderr "✗ FNOX_SYNC_KEYS not set."
+    print --stderr "  Set it in your repo's mise.toml [env]:"
+    print --stderr "    FNOX_SYNC_KEYS = \"CLOUDFLARE_API_TOKEN,CLOUDFLARE_ACCOUNT_ID,...\""
+    exit 1
+  }
+
+  let keys = ($keys_str | split row "," | each { |k| $k | str trim } | where { |k| not ($k | is-empty) })
+  let key_count = ($keys | length)
+  print $"Syncing ($key_count) secrets from fnox → ($repo)..."
+  if $dry { print "  \(dry-run mode — nothing will be pushed\)" }
+
+  mut ok = 0
+  mut skipped = 0
+  mut failed = 0
+
+  for key in $keys {
+    let value = (try { ^fnox get $key | str trim } catch { "" })
+    if ($value | is-empty) {
+      print $"  ⤬ ($key) not in fnox \(skipping\)"
+      $skipped = ($skipped + 1)
+      continue
+    }
+    if $dry {
+      let vlen = ($value | str length)
+      print $"  ✓ ($key) \(would set ($vlen) bytes\)"
+      $ok = ($ok + 1)
+    } else {
+      let result = ($value | ^gh secret set $key --repo $repo | complete)
+      if $result.exit_code == 0 {
+        print $"  ✓ ($key) → ($repo)"
+        $ok = ($ok + 1)
+      } else {
+        print $"  ✗ ($key) failed to set"
+        $failed = ($failed + 1)
+      }
+    }
+  }
+
+  print ""
+  print $"Done. ok=($ok) skipped=($skipped) failed=($failed)"
+  if $failed > 0 { exit 1 }
+}
+'''


### PR DESCRIPTION
## Summary

Adds the **TOML-tasks-with-per-task-tools** mechanism to the shared lib — the cleanest answer to cross-repo `[tools]` propagation that mise actually supports today.

Each task in a `tasks/<ns>.toml` file declares its own `tools = { ... }`. When a consumer's `task_config.includes = ["git::....toml?ref=v0.16.0"]` pulls it in, mise auto-installs those tools when the task runs — without:
- `experimental_monorepo_root` flag
- vendoring `.shared/`
- env-var setup (`MISE_OVERRIDE_CONFIG_FILENAMES` etc.)
- per-namespace `<ns>:install-tools` workaround tasks

Stable mise feature. Works on linux + macos + windows. Validated end-to-end against the real `tasks/*.toml` files we ship.

## What's in this PR

- `tasks/ci.toml` — `ci:parse-check`, `ci:watch`, `ci:clean` (gsv's `check` task depends on `ci:parse-check`)
- `tasks/cf.toml` — `cf:token-check` (gsv's `6-deploy-cloud` and `prove-all` use it)
- `tasks/secrets.toml` — `secrets:sync-github` (gsv consumes via `FNOX_SYNC_KEYS`)
- `.github/workflows/tasks-toml-proof.yml` — cross-OS canary that validates both the mechanism (synthetic fixture) AND the real shipped `.toml` files (loads + discovery + negative-path execution)
- `.github/workflows/monorepo-root-proof.yml` — empirical evidence for the experimental `experimental_monorepo_root` alternative we considered and rejected (kept as documentation)

The legacy `mise-tasks/<ns>/<name>` file-tasks **stay in place** during the migration window — consumers can adopt the new TOML-task includes namespace-by-namespace at their own pace. The existing `mise-tasks-lint.yml` continues to test those.

## Migration path for consumers (e.g. gsv)

Before:
```toml
[task_config]
includes = [
  "mise-tasks",
  "git::https://github.com/joeblew999/.github.git//mise-tasks?ref=v0.15.3",
]
[tools]
"github:nushell/nushell" = "0.112"   # had to know
"github:jdx/fnox"        = "1.24"    # had to know
"github:cli/cli"         = "2"       # had to know
```

After:
```toml
[task_config]
includes = [
  "mise-tasks",
  "git::https://github.com/joeblew999/.github.git//tasks/ci.toml?ref=v0.16.0",
  "git::https://github.com/joeblew999/.github.git//tasks/cf.toml?ref=v0.16.0",
  "git::https://github.com/joeblew999/.github.git//tasks/secrets.toml?ref=v0.16.0",
]
[tools]
"github:nushell/nushell" = "0.112"   # still pin nu for local tasks
# fnox + gh come along automatically with the tasks that need them
```

## Background — why this approach over the alternatives

Empirically tested in this branch:

| Option | Stable? | Tools auto-propagate? | Vendoring? | Env-var setup? |
|---|---|---|---|---|
| Per-namespace `<ns>:install-tools` task | ✓ | ✗ (manual) | ✗ | ✗ |
| `experimental_monorepo_root` + `.shared/` submodule | ✗ experimental | ✓ | ✓ | ✗ |
| `MISE_OVERRIDE_CONFIG_FILENAMES` env var | ✓ | ✓ when set | ✗ | ✓ fragile |
| **TOML-tasks with per-task `tools = {}`** | **✓** | **✓** | **✗** | **✗** |

Discussion #5267 noted that *file* tasks don't propagate `#MISE tools=` headers through remote includes. Empirically, *TOML* tasks with structured `tools = {}` fields go through a different code path and DO propagate.

Both proof workflows pass on linux + macos + windows.

## Test plan

- [x] `tasks-toml proof` — synthetic fixture validation passes 3 OS
- [x] `tasks-toml proof` — real `tasks/ci.toml` discovery + parse-check + negative paths pass 3 OS
- [x] `tasks-toml proof` — real `tasks/cf.toml` + `tasks/secrets.toml` discovery + negative paths pass 3 OS
- [x] `monorepo-root proof` — alternative empirically validated (kept as reference; not used)
- [x] Existing `mise-tasks-lint` continues to test file-task versions
- [ ] After merge + tag `v0.16.0`, migrate gsv as the first consumer + verify gsv CI 3 OS green