### PR TITLE
fix(mobile): guard rustup-target-add when rustup not on PATH

### DIFF
--- a/tasks/mobile.toml
+++ b/tasks/mobile.toml
@@ -81,8 +81,16 @@ def main [] {
     print $"✓ NDK installed: ($env.ANDROID_NDK_HOME)"
   }
 
-  print "→ adding Rust Android targets..."
-  ^rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+  if (which rustup | is-empty) {
+    print "⤬ rustup not on PATH — skipping Rust Android target install."
+    print "  To add targets, ensure `rust` is pinned in your repo's mise.toml,"
+    print "  then re-run this task or call:"
+    print "    rustup target add aarch64-linux-android armv7-linux-androideabi \\"
+    print "                       i686-linux-android x86_64-linux-android"
+  } else {
+    print "→ adding Rust Android targets..."
+    ^rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+  }
 
   print ""
   print "✓ Android toolchain ready."
@@ -129,8 +137,15 @@ def main [] {
   let pod_ver = (^pod --version | str trim)
   print $"✓ CocoaPods ($pod_ver)"
 
-  print "→ adding Rust iOS targets..."
-  ^rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+  if (which rustup | is-empty) {
+    print "⤬ rustup not on PATH — skipping Rust iOS target install."
+    print "  To add targets, ensure `rust` is pinned in your repo's mise.toml,"
+    print "  then re-run this task or call:"
+    print "    rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios"
+  } else {
+    print "→ adding Rust iOS targets..."
+    ^rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+  }
 
   print ""
   print "✓ iOS toolchain ready."


### PR DESCRIPTION
## Summary

Hot-fix to v0.16.1: mobile:android-setup + mobile:ios-setup assumed rustup was on PATH (true if consumer pins rust in their own mise.toml). For consumers adopting mobile:* without rust pinned, the task crashed with `Command 'rustup' not found`.

Fix: detect rustup via `which rustup`, skip the target-add step with a friendly hint when missing. Setup task still completes — verifying Xcode/Java/CocoaPods is the load-bearing part.

## Verified locally

```
$ mise run mobile:ios-setup
✓ Xcode: /Applications/Xcode.app/Contents/Developer
✓ CocoaPods 1.16.2
⤬ rustup not on PATH — skipping Rust iOS target install.
  To add targets, ensure `rust` is pinned in your repo's mise.toml,
  then re-run this task or call:
    rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios

✓ iOS toolchain ready.
```

Will tag v0.16.2 after merge.

## Test plan

- [x] Local `mise run mobile:ios-setup` against fixture with only nushell pinned — passes
- [ ] tasks-toml-proof workflow (3 OS, discovery only — execution still NOT triggered for mobile)