### PR TITLE
feat(tasks): port env:* + wrangler:* to TOML (v0.17.1)

### DIFF
--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -387,6 +387,62 @@ jobs:
           }
           print "✓ cf:* negative paths fire with expected env-file error"
 
+      # ── Real-file validation: env.toml + wrangler.toml (v0.17.1+) ──────
+      - name: Real env.toml + wrangler.toml — discovery + negative paths
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "envwr-consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+
+          let env_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "env.toml")
+          let wr_toml  = ($env.GITHUB_WORKSPACE | path join "tasks" "wrangler.toml")
+          let root_toml = $"[task_config]
+          includes = ['($env_toml)', '($wr_toml)']
+
+          [tools]
+          \"github:nushell/nushell\" = \"0.112\"
+          "
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          cd $root
+          ^mise trust
+
+          # wrangler:* — 5 visible tasks
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          for t in ["wrangler:deploy", "wrangler:dev", "wrangler:gen", "wrangler:secret-list", "wrangler:tail"] {
+            if not ($listing.stdout | str contains $t) {
+              print --stderr $"✗ ($t) not discovered"
+              exit 1
+            }
+          }
+          print "✓ all 5 wrangler:* tasks discovered"
+
+          # env:resolve — hidden but invocable
+          let r = (^mise run "env:resolve" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ env:resolve should have failed (no config/<env>.env)"
+            exit 1
+          }
+          if not (($r.stdout + $r.stderr) | str contains "config/production.env not found") {
+            print --stderr $"✗ env:resolve wrong error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ env:resolve discovered + fails cleanly with no config dir"
+
+          # wrangler:gen — also reads env file, fails with same message
+          let r2 = (^mise run "wrangler:gen" | complete)
+          if $r2.exit_code == 0 {
+            print --stderr "✗ wrangler:gen should have failed"
+            exit 1
+          }
+          if not (($r2.stdout + $r2.stderr) | str contains "config/production.env not found") {
+            print --stderr $"✗ wrangler:gen wrong error: ($r2.stderr)"
+            exit 1
+          }
+          print "✓ wrangler:gen fails cleanly"
+
       # ── Real-file validation: mobile.toml ───────────────────────────────
       # Discovery only — we don't actually run any mobile:* task here.
       # mobile:android-setup would trigger a Temurin JDK install (~200 MB)

--- a/tasks/env.toml
+++ b/tasks/env.toml
@@ -1,0 +1,35 @@
+# tasks/env.toml — TOML-task definitions for the env:* namespace.
+#
+# Currently this is just env:resolve — a hidden helper used by other shared
+# tasks to find the active config/<env>.env file. Per-consumer env tasks
+# (env:dump, env:list, env:use) live in each consumer's own mise.toml as
+# inline [tasks."env:..."] blocks; they're project-specific.
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/env.toml?ref=v0.17.1",
+#   ]
+
+# ── env:resolve ──────────────────────────────────────────────────────────────
+# Resolve which config/<env>.env file to read; default `production`.
+# Hidden helper — `mise tasks ls` skips it. Other shared tasks invoke it
+# to get the active env file path.
+["env:resolve"]
+description = "resolve which config/<env>.env file to read; default `production`. Prints path. Hidden helper used by other shared tasks."
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let env_name = ($env.MISE_ENV? | default ($env.ENV? | default "production"))
+  let file = $"config/($env_name).env"
+  if not ($file | path exists) {
+    print --stderr $"ERROR: ($file) not found."
+    print --stderr $"       cp config/template.env ($file)  and fill it in."
+    exit 1
+  }
+  print -n $file
+}
+'''

--- a/tasks/wrangler.toml
+++ b/tasks/wrangler.toml
@@ -1,0 +1,131 @@
+# tasks/wrangler.toml — TOML-task definitions for the wrangler:* namespace.
+#
+# Thin wrappers around the wrangler CLI plus wrangler:gen, the
+# template-substitution config generator that's how joeblew999 consumers
+# parameterise their wrangler.{toml,jsonc} from config/<env>.env files.
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/wrangler.toml?ref=v0.17.1",
+#   ]
+#
+# All wrangler:* tasks pin npm:wrangler per-task; consumers don't have to
+# pin wrangler globally just because a deploy/dev/tail task uses it.
+
+# ── wrangler:deploy ──────────────────────────────────────────────────────────
+# Pass-through to `wrangler deploy`. Forwards all args verbatim.
+["wrangler:deploy"]
+description = "deploy to Cloudflare Workers"
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  ^wrangler deploy ...$args
+}
+'''
+
+# ── wrangler:dev ─────────────────────────────────────────────────────────────
+# Pass-through to `wrangler dev` for local multi-worker development.
+["wrangler:dev"]
+description = "wrangler local dev (multi-worker)"
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  ^wrangler dev ...$args
+}
+'''
+
+# ── wrangler:gen ─────────────────────────────────────────────────────────────
+# Generate wrangler.{toml,jsonc} from wrangler.{toml,jsonc}.template +
+# config/<env>.env. Auto-detects which template format the fork uses.
+# Per-fork values are interpolated; the result is gitignored.
+#
+# Note: this task does NOT call wrangler — it's pure nu template
+# substitution. So no npm:wrangler in tools.
+["wrangler:gen"]
+description = "Generate wrangler.{toml,jsonc} from wrangler.{toml,jsonc}.template + config/<env>.env via bash native substitution. Auto-detects which template format the fork uses. Per-fork values are interpolated; the result is gitignored."
+tools = { "github:nushell/nushell" = "0.112" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let env_name = ($env.MISE_ENV? | default ($env.ENV? | default "production"))
+  let env_file = $"config/($env_name).env"
+  if not ($env_file | path exists) {
+    print --stderr $"ERROR: ($env_file) not found."
+    exit 1
+  }
+
+  let pair = if ("wrangler.toml.template" | path exists) {
+    {src: "wrangler.toml.template", dst: "wrangler.toml"}
+  } else if ("wrangler.jsonc.template" | path exists) {
+    {src: "wrangler.jsonc.template", dst: "wrangler.jsonc"}
+  } else {
+    print --stderr $"ERROR: no wrangler.{toml,jsonc}.template found in \(pwd\)"
+    exit 1
+  }
+
+  # Substitute ${KEY} and $KEY for every defined KEY=VAL in env_file.
+  let env_pairs = (
+    open --raw $env_file
+    | lines
+    | where { |l| $l =~ '^[A-Z_][A-Z0-9_]*=' }
+    | each {|line|
+        let parts = ($line | split row -n 2 "=")
+        let key = ($parts | get 0)
+        let val = (($parts | get 1) | str trim --char '"')
+        {key: $key, val: $val}
+      }
+  )
+
+  let template = (open --raw $pair.src)
+  let output = ($env_pairs | reduce -f $template {|p, acc|
+    $acc
+    | str replace --all $"${($p.key)}" $p.val
+    | str replace --all $"$($p.key)" $p.val
+  })
+
+  $output | save -f $pair.dst
+  print $"wrote ($pair.dst) from ($pair.src) \(env: ($env_file)\)"
+}
+'''
+
+# ── wrangler:secret-list ─────────────────────────────────────────────────────
+# List secrets set on a deployed Worker (values hidden).
+["wrangler:secret-list"]
+description = "list secrets set on a deployed Worker (values hidden)"
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+usage = '''
+flag "--env <env>" help="Cloudflare environment" default="production"
+'''
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  # mise's `usage` flag --env populates $env.usage_env; fall back to ENV var, then 'production'
+  let cf_env = ($env.usage_env? | default ($env.ENV? | default "production"))
+  ^wrangler secret list --env $cf_env ...$args
+}
+'''
+
+# ── wrangler:tail ────────────────────────────────────────────────────────────
+# Tail live logs from a deployed Worker. Defaults to production env;
+# pass --env <env> for staging/preview.
+["wrangler:tail"]
+description = "tail live logs from a deployed Worker"
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+usage = '''
+flag "--env <env>" help="Cloudflare environment to tail" default="production"
+'''
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  let cf_env = ($env.usage_env? | default ($env.ENV? | default "production"))
+  ^wrangler tail --env $cf_env ...$args
+}
+'''


### PR DESCRIPTION
## Summary

Two more namespaces ported. Both small enough to batch as v0.17.1 (patch bump — additive only).

| Task | Per-task tools |
|---|---|
| `env:resolve` (hidden helper) | nu |
| `wrangler:deploy` | nu, npm:wrangler |
| `wrangler:dev` | nu, npm:wrangler |
| `wrangler:gen` | nu (pure template substitution) |
| `wrangler:secret-list` | nu, npm:wrangler |
| `wrangler:tail` | nu, npm:wrangler |

## Why batch them

env namespace is only 1 shared task. The other env names (`env:dump`, `env:list`, `env:use`) consumers reference are project-specific inline `[tasks."env:..."]` blocks in each consumer's mise.toml — they differ per repo and don't belong upstream.

Both env + wrangler unblock the same 5 consumers (agentic-inbox, auth-service, d1-manager, kv-manager, saasmail).

## Validation

`tasks-toml-proof.yml` extended:
- 5 wrangler:* visible + discoverable
- env:resolve hidden but invocable (`hide = true` flag respected by `mise tasks ls`, but `mise run env:resolve` still works)
- env:resolve + wrangler:gen both fail cleanly with "config/production.env not found" under empty fixture

## Tag

After merge: tag `v0.17.1`. Consumers can switch their includes:

```toml
includes = [
  "git::....git//tasks/env.toml?ref=v0.17.1",
  "git::....git//tasks/wrangler.toml?ref=v0.17.1",
]
```

## Test plan

- [x] All tasks discoverable locally
- [x] Negative paths fire correctly locally
- [ ] tasks-toml-proof workflow green on linux+macos+windows