### PR TITLE
feat(tasks): port prove:* + fix wrangler:gen desc (v0.17.2)

### DIFF
--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -443,6 +443,54 @@ jobs:
           }
           print "✓ wrangler:gen fails cleanly"
 
+      # ── Real-file validation: prove.toml (v0.17.2+) ────────────────────
+      - name: Real prove.toml — discovery + negative paths
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "prove-consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+
+          let prove_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "prove.toml")
+          let root_toml = $"[task_config]
+          includes = ['($prove_toml)']
+
+          [tools]
+          \"github:nushell/nushell\" = \"0.112\"
+          "
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          cd $root
+          ^mise trust
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          for t in ["prove:access-policy", "prove:bindings", "prove:deployed", "prove:secrets"] {
+            if not ($listing.stdout | str contains $t) {
+              print --stderr $"✗ ($t) not discovered"
+              exit 1
+            }
+          }
+          print "✓ all 4 prove:* tasks discovered"
+
+          # 2 tasks read config/<env>.env first — both fail-cleanly with
+          # the "config/production.env not found" message. The other two
+          # (prove:bindings + prove:secrets) call ^wrangler immediately
+          # which would need a real auth context to test meaningfully —
+          # skip those in CI.
+          for t in ["prove:deployed", "prove:access-policy"] {
+            let r = (^mise run $t | complete)
+            if $r.exit_code == 0 {
+              print --stderr $"✗ ($t) should have failed"
+              exit 1
+            }
+            if not (($r.stdout + $r.stderr) | str contains "config/production.env not found") {
+              print --stderr $"✗ ($t) wrong error: ($r.stderr)"
+              exit 1
+            }
+            print $"  ✓ ($t) failed cleanly"
+          }
+          print "✓ prove:* config-reading tasks fire expected error"
+
       # ── Real-file validation: mobile.toml ───────────────────────────────
       # Discovery only — we don't actually run any mobile:* task here.
       # mobile:android-setup would trigger a Temurin JDK install (~200 MB)

--- a/tasks/prove.toml
+++ b/tasks/prove.toml
@@ -1,0 +1,191 @@
+# tasks/prove.toml — TOML-task definitions for the prove:* namespace.
+#
+# Post-deploy verification primitives: each prove:* task asserts ONE
+# specific property of the deployed Worker. Composites that chain them
+# (prove:all, prove:sso-rbac) live in each consumer's mise.toml — they're
+# project-specific.
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/prove.toml?ref=v0.17.2",
+#   ]
+
+# ── prove:bindings ───────────────────────────────────────────────────────────
+# Confirm the deployed Worker's bindings via wrangler --dry-run (no upload).
+# Catches drift between wrangler.toml.template and the resources actually
+# created.
+["prove:bindings"]
+description = "Confirm the deployed Worker's bindings via wrangler --dry-run (no upload). Catches drift between wrangler.toml.template and the resources actually created."
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  print "→ wrangler deploy --dry-run"
+  let raw = (^wrangler deploy --dry-run --outdir build/dryrun | complete | get stdout)
+  $raw
+  | lines
+  | where { |l| ($l =~ '^Binding') or ($l =~ '^Total Upload') or ($l =~ 'env\.') or ($l =~ '^\s+env\.') }
+  | first 20
+  | str join "\n"
+  | print
+}
+'''
+
+# ── prove:secrets ────────────────────────────────────────────────────────────
+# List secrets on the deployed Worker, assert all 4 expected names are
+# present (ACCOUNT_ID, API_KEY, TEAM_DOMAIN, POLICY_AUD).
+["prove:secrets"]
+description = "List secrets on the deployed Worker, assert all 4 expected names present (ACCOUNT_ID, API_KEY, TEAM_DOMAIN, POLICY_AUD)."
+tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let out = (^wrangler secret list | complete | get stdout)
+  print $out
+  print ""
+  for k in ["ACCOUNT_ID", "API_KEY", "TEAM_DOMAIN", "POLICY_AUD"] {
+    let needle = $'"($k)"'
+    if ($out | str contains $needle) {
+      print $"  ✓ ($k) present"
+    } else {
+      print --stderr $"  ✗ ($k) MISSING — run cf:secrets-put-mapped"
+      exit 1
+    }
+  }
+}
+'''
+
+# ── prove:deployed ───────────────────────────────────────────────────────────
+# Smoke-test the deployed Worker — expect 302 to CF Access challenge with
+# the AUD stored in fnox under APP_POLICY_AUD_FNOX_KEY.
+["prove:deployed"]
+description = "Smoke-test the deployed Worker — expect 302 to CF Access challenge with the AUD stored in fnox under APP_POLICY_AUD_FNOX_KEY."
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let env_name = ($env.MISE_ENV? | default ($env.ENV? | default "production"))
+  let file = $"config/($env_name).env"
+  if not ($file | path exists) {
+    print --stderr $"ERROR: ($file) not found."
+    exit 1
+  }
+  let cfg = (
+    open --raw $file
+    | lines
+    | where { |l| $l =~ '^[A-Z_][A-Z0-9_]*=' }
+    | reduce -f {} {|line, acc|
+        let parts = ($line | split row -n 2 "=")
+        $acc | upsert ($parts | get 0) (($parts | get 1) | str trim --char '"')
+      }
+  )
+
+  let worker = ($cfg.WORKER_NAME? | default "")
+  let subdomain = ($cfg.CF_SUBDOMAIN? | default "")
+  let aud_key = ($cfg.APP_POLICY_AUD_FNOX_KEY? | default "")
+  if ($worker | is-empty) or ($subdomain | is-empty) or ($aud_key | is-empty) {
+    print --stderr "WORKER_NAME, CF_SUBDOMAIN, APP_POLICY_AUD_FNOX_KEY all required in config"
+    exit 1
+  }
+
+  let url = $"https://($worker).($subdomain).workers.dev"
+  let expected_aud = (^fnox get $aud_key | str trim)
+
+  print $"GET ($url)"
+  let raw_headers = (^curl -sI $url | str replace --all "\r" "")
+  let lines = ($raw_headers | lines)
+  let status = ($lines | first)
+  let loc = (
+    $lines
+    | where { |l| ($l | str downcase | str starts-with "location:") }
+    | first
+    | default ""
+    | str replace --regex '(?i)^location:\s*' ''
+    | str trim
+  )
+  print $"  ($status)"
+  let preview = ($loc | str substring 0..120)
+  print $"  location: ($preview)..."
+
+  if not ($status =~ '^HTTP/[0-9.]+\s+302') {
+    print --stderr $"✗ expected 302, got: ($status)"
+    exit 1
+  }
+  if not ($loc | str contains "/cdn-cgi/access/login/") {
+    print --stderr "✗ location is not a CF Access challenge URL"
+    exit 1
+  }
+  if not ($loc | str contains $"kid=($expected_aud)") {
+    print --stderr $"✗ challenge AUD does not match fnox:($aud_key)"
+    exit 1
+  }
+  print "✓ CF Access is gating with the correct app AUD"
+}
+'''
+
+# ── prove:access-policy ──────────────────────────────────────────────────────
+# Verify the CF Access App for this Worker has at least one allow policy.
+# Without one, login 403s after OAuth.
+["prove:access-policy"]
+description = "Verify the CF Access App for this Worker has at least one allow policy. Without one, login 403s after OAuth."
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+run = '''
+#!/usr/bin/env nu
+
+def main [] {
+  let env_name = ($env.MISE_ENV? | default ($env.ENV? | default "production"))
+  let file = $"config/($env_name).env"
+  if not ($file | path exists) {
+    print --stderr $"ERROR: ($file) not found."
+    exit 1
+  }
+  let cfg = (
+    open --raw $file
+    | lines
+    | where { |l| $l =~ '^[A-Z_][A-Z0-9_]*=' }
+    | reduce -f {} {|line, acc|
+        let parts = ($line | split row -n 2 "=")
+        $acc | upsert ($parts | get 0) (($parts | get 1) | str trim --char '"')
+      }
+  )
+
+  let worker = ($cfg.WORKER_NAME? | default "")
+  let subdomain = ($cfg.CF_SUBDOMAIN? | default "")
+  if ($worker | is-empty) or ($subdomain | is-empty) {
+    print --stderr "WORKER_NAME, CF_SUBDOMAIN required in config"
+    exit 1
+  }
+
+  let token = (^fnox get CLOUDFLARE_API_TOKEN | str trim)
+  let account = (^fnox get CLOUDFLARE_ACCOUNT_ID | str trim)
+  let app_domain = $"($worker).($subdomain).workers.dev"
+  let api = $"https://api.cloudflare.com/client/v4/accounts/($account)"
+  let auth = $"Authorization: Bearer ($token)"
+
+  let apps_resp = (^curl -sS -H $auth $"($api)/access/apps" | from json)
+  let app = ($apps_resp.result | where domain == $app_domain | first)
+  if ($app | is-empty) {
+    print --stderr $"✗ no Access App found for ($app_domain) — run cf:access-setup first"
+    exit 1
+  }
+  let app_id = $app.id
+
+  let pol_resp = (^curl -sS -H $auth $"($api)/access/apps/($app_id)/policies" | from json)
+  let allow_policies = ($pol_resp.result | where decision == "allow")
+  let allow_count = ($allow_policies | length)
+  if $allow_count < 1 {
+    print --stderr $"✗ Access App ($app_domain) has no allow policy. Login would 403 after OAuth."
+    print --stderr "  Re-run cf:access-setup with OPERATOR_EMAIL set in config/<env>.env."
+    exit 1
+  }
+  print $"✓ Access App ($app_domain) has ($allow_count) allow policy/policies"
+  for p in $allow_policies {
+    let include_keys = ($p.include | each { |i| $i | columns | first } | str join ",")
+    print $"  - ($p.name): ($p.decision) [($include_keys)]"
+  }
+}
+'''

--- a/tasks/wrangler.toml
+++ b/tasks/wrangler.toml
@@ -47,7 +47,7 @@ def main [...args] {
 # Note: this task does NOT call wrangler — it's pure nu template
 # substitution. So no npm:wrangler in tools.
 ["wrangler:gen"]
-description = "Generate wrangler.{toml,jsonc} from wrangler.{toml,jsonc}.template + config/<env>.env via bash native substitution. Auto-detects which template format the fork uses. Per-fork values are interpolated; the result is gitignored."
+description = "Generate wrangler.{toml,jsonc} from wrangler.{toml,jsonc}.template + config/<env>.env via nushell template substitution. Auto-detects which template format the fork uses. Per-fork values are interpolated; the result is gitignored."
 tools = { "github:nushell/nushell" = "0.112" }
 run = '''
 #!/usr/bin/env nu


### PR DESCRIPTION
## Summary

Ports the prove:* namespace (4 tasks) and folds in a one-line description fix for wrangler:gen.

| Task | Tools |
|---|---|
| `prove:access-policy` | nu, fnox |
| `prove:bindings` | nu, npm:wrangler |
| `prove:deployed` | nu, fnox |
| `prove:secrets` | nu, npm:wrangler |

## Test plan

- [x] All 4 discoverable locally
- [x] prove:deployed + prove:access-policy fail-clean with no env file
- [ ] tasks-toml-proof on linux+macos+windows

## Gemini feedback acknowledgement

PR #40 + #41 reviews flagged broader refactors across cf:*/prove:* (mise native env._.file loading, nu http vs ^curl, structured wrangler JSON output, etc). Those are batched into a v0.18 refactor pass — captured in project-memory. This PR sticks to verbatim ports for behavior preservation.