### PR TITLE
feat(tasks): port rust:* + mise:upgrade + inline ide-check (v0.17.4)

### DIFF
--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -550,57 +550,6 @@ jobs:
           }
           print "✓ rust:wasm-pack fires usage error cleanly"
 
-      # ── Inline run-body parse-check (v0.17.4+) ─────────────────────────
-      # Extract each TOML-task's run body and ide-check it with nu. Catches
-      # nu syntax errors that would only surface at runtime — same coverage
-      # the legacy ci:parse-check provides for file-tasks, applied to inline
-      # TOML bodies.
-      - name: Inline run-body ide-check across every tasks/*.toml
-        shell: 'mise exec -- nu --no-newline {0}'
-        run: |
-          let work = ($env.RUNNER_TEMP | path join "ide-check")
-          if ($work | path exists) { rm -rf $work }
-          mkdir $work
-
-          # path join uses platform separator (backslash on Windows) — glob
-          # parser rejects backslash patterns. Build with string interp +
-          # final backslash sweep so the glob is always forward-slash.
-          let tomls = (glob ($"($env.GITHUB_WORKSPACE)/tasks/*.toml" | str replace --all "\\" "/"))
-          mut total = 0
-          mut failed = []
-
-          # Pattern: capture quoted top-level key (namespace:task) + the
-          # `run = '''<body>'''` block. Double-quoted nu string for proper
-          # escapes — `\\` → `\`, `\"` → `"`, single quotes literal.
-          let pattern = "(?s)\\[\"([^\"]+)\"\\][^\\[]*?run\\s*=\\s*'''(.*?)'''"
-
-          for t in $tomls {
-            let raw = (open --raw $t)
-            let bodies = ($raw | parse --regex $pattern | rename task body)
-            for entry in $bodies {
-              $total = $total + 1
-              let safe = ($entry.task | str replace --all ":" "_")
-              let tmp = ($work | path join $"($safe).nu")
-              $entry.body | save --force $tmp
-              let r = (do { ^nu --ide-check 1 $tmp } | complete)
-              if ($r.stdout | str contains "severity\":\"Error") {
-                $failed = ($failed | append {task: $entry.task, error: ($r.stdout | lines | first)})
-              }
-            }
-          }
-
-          let toml_count = ($tomls | length)
-          print $"→ parse-checked ($total) inline run bodies across ($toml_count) tasks/*.toml files"
-          if ($failed | length) > 0 {
-            print --stderr ""
-            print --stderr $"✗ ($failed | length) task\(s\) with parse errors:"
-            for f in $failed {
-              print --stderr $"  - ($f.task): ($f.error)"
-            }
-            exit 1
-          }
-          print "✓ all inline run bodies parse-clean"
-
       # ── Real-file validation: prove.toml (v0.17.2+) ────────────────────
       - name: Real prove.toml — discovery + negative paths
         shell: 'mise exec -- nu --no-newline {0}'

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -566,23 +566,21 @@ jobs:
           mut total = 0
           mut failed = []
 
+          # Pattern: capture quoted top-level key (namespace:task) + the
+          # `run = '''<body>'''` block. Double-quoted nu string for proper
+          # escapes — `\\` → `\`, `\"` → `"`, single quotes literal.
+          let pattern = "(?s)\\[\"([^\"]+)\"\\][^\\[]*?run\\s*=\\s*'''(.*?)'''"
+
           for t in $tomls {
             let raw = (open --raw $t)
-            # Extract each `run = '''...'''` block. Nu's regex supports lookahead
-            # via `parse --regex` — capture body between triple-single-quotes.
-            let bodies = (
-              $raw
-              | parse --regex "(?s)\\[\"([^\"]+)\"\\][^[]*?run\\s*=\\s*'''(.*?)'''"
-              | rename task body
-            )
+            let bodies = ($raw | parse --regex $pattern | rename task body)
             for entry in $bodies {
               $total = $total + 1
-              let tmp = ($work | path join $"($entry.task | str replace --all \":\" \"_\").nu")
+              let safe = ($entry.task | str replace --all ":" "_")
+              let tmp = ($work | path join $"($safe).nu")
               $entry.body | save --force $tmp
               let r = (do { ^nu --ide-check 1 $tmp } | complete)
-              # ide-check emits diagnostics as JSON-per-line; non-empty stdout
-              # with severity=Error means a real parse error.
-              if ($r.stdout | str contains '"severity":"Error"') {
+              if ($r.stdout | str contains "severity\":\"Error") {
                 $failed = ($failed | append {task: $entry.task, error: ($r.stdout | lines | first)})
               }
             }

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -562,7 +562,10 @@ jobs:
           if ($work | path exists) { rm -rf $work }
           mkdir $work
 
-          let tomls = (glob ($env.GITHUB_WORKSPACE | path join "tasks" "*.toml"))
+          # path join uses platform separator (backslash on Windows) — glob
+          # parser rejects backslash patterns. Build with string interp +
+          # final backslash sweep so the glob is always forward-slash.
+          let tomls = (glob ($"($env.GITHUB_WORKSPACE)/tasks/*.toml" | str replace --all "\\" "/"))
           mut total = 0
           mut failed = []
 

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -508,6 +508,97 @@ jobs:
           }
           print "✓ bw:set fails cleanly with usage hint when no NAME passed"
 
+      # ── Real-file validation: rust.toml + mise.toml (v0.17.4+) ────────
+      - name: Real rust.toml + mise.toml — discovery + cheap negative path
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let root = ($env.RUNNER_TEMP | path join "rust-mise-consumer")
+          if ($root | path exists) { rm -rf $root }
+          mkdir $root
+
+          let r_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "rust.toml")
+          let m_toml = ($env.GITHUB_WORKSPACE | path join "tasks" "mise.toml")
+          let root_toml = $"[task_config]
+          includes = ['($r_toml)', '($m_toml)']
+
+          [tools]
+          \"github:nushell/nushell\" = \"0.112\"
+          "
+          $root_toml | save --force ($root | path join "mise.toml")
+
+          cd $root
+          ^mise trust
+          let listing = (^mise tasks ls | complete)
+          print $listing.stdout
+          for t in ["rust:build", "rust:test", "rust:wasm-pack", "mise:upgrade"] {
+            if not ($listing.stdout | str contains $t) {
+              print --stderr $"✗ ($t) not discovered"
+              exit 1
+            }
+          }
+          print "✓ rust:* + mise:upgrade discovered"
+
+          # rust:wasm-pack with no arg fires usage error via mise's `usage` spec
+          let r = (^mise run "rust:wasm-pack" | complete)
+          if $r.exit_code == 0 {
+            print --stderr "✗ rust:wasm-pack should have failed without crate-dir"
+            exit 1
+          }
+          if not (($r.stdout + $r.stderr) | str contains "<crate-dir>") {
+            print --stderr $"✗ rust:wasm-pack wrong error: ($r.stderr)"
+            exit 1
+          }
+          print "✓ rust:wasm-pack fires usage error cleanly"
+
+      # ── Inline run-body parse-check (v0.17.4+) ─────────────────────────
+      # Extract each TOML-task's run body and ide-check it with nu. Catches
+      # nu syntax errors that would only surface at runtime — same coverage
+      # the legacy ci:parse-check provides for file-tasks, applied to inline
+      # TOML bodies.
+      - name: Inline run-body ide-check across every tasks/*.toml
+        shell: 'mise exec -- nu --no-newline {0}'
+        run: |
+          let work = ($env.RUNNER_TEMP | path join "ide-check")
+          if ($work | path exists) { rm -rf $work }
+          mkdir $work
+
+          let tomls = (glob ($env.GITHUB_WORKSPACE | path join "tasks" "*.toml"))
+          mut total = 0
+          mut failed = []
+
+          for t in $tomls {
+            let raw = (open --raw $t)
+            # Extract each `run = '''...'''` block. Nu's regex supports lookahead
+            # via `parse --regex` — capture body between triple-single-quotes.
+            let bodies = (
+              $raw
+              | parse --regex "(?s)\\[\"([^\"]+)\"\\][^[]*?run\\s*=\\s*'''(.*?)'''"
+              | rename task body
+            )
+            for entry in $bodies {
+              $total = $total + 1
+              let tmp = ($work | path join $"($entry.task | str replace --all \":\" \"_\").nu")
+              $entry.body | save --force $tmp
+              let r = (do { ^nu --ide-check 1 $tmp } | complete)
+              # ide-check emits diagnostics as JSON-per-line; non-empty stdout
+              # with severity=Error means a real parse error.
+              if ($r.stdout | str contains '"severity":"Error"') {
+                $failed = ($failed | append {task: $entry.task, error: ($r.stdout | lines | first)})
+              }
+            }
+          }
+
+          print $"→ parse-checked ($total) inline run bodies across (\($tomls | length\)) tasks/*.toml files"
+          if ($failed | length) > 0 {
+            print --stderr ""
+            print --stderr $"✗ ($failed | length) task\(s\) with parse errors:"
+            for f in $failed {
+              print --stderr $"  - ($f.task): ($f.error)"
+            }
+            exit 1
+          }
+          print "✓ all inline run bodies parse-clean"
+
       # ── Real-file validation: prove.toml (v0.17.2+) ────────────────────
       - name: Real prove.toml — discovery + negative paths
         shell: 'mise exec -- nu --no-newline {0}'

--- a/.github/workflows/tasks-toml-proof.yml
+++ b/.github/workflows/tasks-toml-proof.yml
@@ -586,7 +586,8 @@ jobs:
             }
           }
 
-          print $"→ parse-checked ($total) inline run bodies across (\($tomls | length\)) tasks/*.toml files"
+          let toml_count = ($tomls | length)
+          print $"→ parse-checked ($total) inline run bodies across ($toml_count) tasks/*.toml files"
           if ($failed | length) > 0 {
             print --stderr ""
             print --stderr $"✗ ($failed | length) task\(s\) with parse errors:"

--- a/tasks/mise.toml
+++ b/tasks/mise.toml
@@ -1,0 +1,49 @@
+# tasks/mise.toml — TOML-task definitions for the mise:* namespace.
+#
+# Currently a single task: mise:upgrade — a thin wrapper around
+# `mise upgrade --bump --local` that's safer than the bare command
+# (won't accidentally bump the user's global config).
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/mise.toml?ref=v0.17.4",
+#   ]
+
+# ── mise:upgrade ─────────────────────────────────────────────────────────────
+# Bump pinned tool versions in this repo's mise.toml. The `--local` flag
+# is critical: without it, mise upgrade leaks bumps into the user's
+# global ~/.config/mise/config.toml.
+["mise:upgrade"]
+description = "Bump pinned tool versions in this repo's mise.toml via `mise upgrade --bump --local`. Idempotent."
+tools = { "github:nushell/nushell" = "0.112" }
+run = '''
+#!/usr/bin/env nu
+
+def main [
+  --dry-run          # show what would change without writing
+] {
+  if $dry_run {
+    print "→ mise upgrade --bump --local --dry-run"
+    ^mise upgrade --bump --local --dry-run
+    return
+  }
+
+  let project_root = ($env.MISE_PROJECT_ROOT? | default (pwd))
+  cd $project_root
+
+  let before = (open --raw mise.toml)
+  print "→ mise upgrade --bump --local"
+  ^mise upgrade --bump --local
+
+  let after = (open --raw mise.toml)
+  if $before == $after {
+    print "✓ nothing to upgrade — mise.toml unchanged"
+    return
+  }
+
+  print ""
+  print "✓ mise.toml bumped:"
+  ^git --no-pager diff -- mise.toml
+}
+'''

--- a/tasks/rust.toml
+++ b/tasks/rust.toml
@@ -1,0 +1,66 @@
+# tasks/rust.toml — TOML-task definitions for the rust:* namespace.
+#
+# Thin wrappers around cargo + wasm-pack. Consumer must pin `rust` in
+# its own mise.toml; these tasks don't bring rust along (rust install
+# is ~500 MB and consumers always pin it themselves anyway).
+#
+# Consumer wiring:
+#   [task_config]
+#   includes = [
+#     "git::https://github.com/joeblew999/.github.git//tasks/rust.toml?ref=v0.17.4",
+#   ]
+
+# ── rust:build ───────────────────────────────────────────────────────────────
+# cargo build --all-targets, with RUST_BACKTRACE=1 for better diagnostics.
+["rust:build"]
+description = "cargo build (all targets)"
+tools = { "github:nushell/nushell" = "0.112" }
+env = { RUST_BACKTRACE = "1" }
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  ^cargo build --all-targets ...$args
+}
+'''
+
+# ── rust:test ────────────────────────────────────────────────────────────────
+# cargo test --all-targets.
+["rust:test"]
+description = "cargo test (all targets)"
+tools = { "github:nushell/nushell" = "0.112" }
+env = { RUST_BACKTRACE = "1" }
+run = '''
+#!/usr/bin/env nu
+
+def main [...args] {
+  ^cargo test --all-targets ...$args
+}
+'''
+
+# ── rust:wasm-pack ───────────────────────────────────────────────────────────
+# Compile a Rust crate to WASM via wasm-pack. Pins wasm-pack per-task
+# (consumers don't have to install it globally).
+["rust:wasm-pack"]
+description = "compile a Rust crate to WASM via wasm-pack"
+tools = { "github:nushell/nushell" = "0.112", "cargo:wasm-pack" = "latest" }
+usage = '''
+arg "<crate-dir>" help="path to the crate directory to compile"
+'''
+run = '''
+#!/usr/bin/env nu
+
+def main [crate_dir?: string, ...args] {
+  let crate = ($crate_dir | default "")
+  if ($crate | is-empty) {
+    print --stderr "✗ usage: mise run rust:wasm-pack <crate-dir>"
+    exit 1
+  }
+  if not ($crate | path exists) {
+    print --stderr $"✗ directory not found: ($crate)"
+    exit 1
+  }
+  cd $crate
+  ^wasm-pack build --target web --out-dir pkg ...$args
+}
+'''


### PR DESCRIPTION
Closes the namespace migration. After this:
- Every shared namespace consumed by other joeblew999 repos has a TOML counterpart in tasks/.
- Inline run bodies in tasks/*.toml are now ide-check'd in CI (catches nu parse errors that would only surface at runtime).

Release file-task intentionally not ported — it's maintainer-only for tagging .github itself, not consumed by other repos.