### PR TITLE
refactor(tasks): extends-based tools dedup across all namespaces (v0.18)

### DIFF
--- a/tasks/bw.toml
+++ b/tasks/bw.toml
@@ -15,13 +15,22 @@
 # v0.10.0 file-tasks required consumers to declare it themselves; with
 # TOML-tasks it auto-installs only when a bw:* task runs.
 
+# ── bw:_base ───────────────────────────────────────────────────────────────
+# Hidden base task — every bw:* extends this for shared nu+fnox+bw tools.
+# Dry-run wrappers (sync-dry, migrate-from-keychain-dry) get bw installed
+# even though they only call ^mise; tiny over-install, acceptable.
+["bw:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 # ── bw:status ────────────────────────────────────────────────────────────────
 # Show bw login status against NodeWarden (server URL, lock state, email).
 # Reads BW_SESSION from fnox keychain. Fails-fast if bw is missing or
 # BW_SESSION is unset.
 ["bw:status"]
+extends = "bw:_base"
 description = "Show bw login status against NodeWarden (server URL, lock state, email). Reads BW_SESSION from fnox keychain."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -47,8 +56,9 @@ print $"  userEmail: ($s.userEmail? | default '?')"
 # Refresh BW_SESSION (vault auto-locks after inactivity). Hidden prompt
 # for master password, stores new session in fnox keychain.
 ["bw:unlock"]
+extends = "bw:_base"
 description = "Refresh BW_SESSION (vault auto-locks after inactivity). Hidden prompt for master password, stores new session in fnox keychain."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -81,8 +91,9 @@ print "✓ BW_SESSION refreshed in fnox keychain"
 # ── bw:list ──────────────────────────────────────────────────────────────────
 # List item names + sizes in your NodeWarden vault. Values are NOT shown.
 ["bw:list"]
+extends = "bw:_base"
 description = "List item names + sizes in your NodeWarden vault. Values are NOT shown."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -114,8 +125,9 @@ if ($status.status? != "unlocked") {
 # Show drift between keychain and NodeWarden — which keys are in each,
 # which match. Values are NOT revealed (only sha256 prefix comparison).
 ["bw:diff"]
+extends = "bw:_base"
 description = "Show drift between keychain and NodeWarden — which keys are in each, which match. Values are NOT revealed (only sha256 prefix comparison)."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -186,8 +198,9 @@ for k in $all_keys {
 # keychain. Use to rotate a secret on Mac (kept consistent in both
 # stores in one shot).
 ["bw:set"]
+extends = "bw:_base"
 description = "Write-through: hidden-input prompt → set NodeWarden item + mirror to keychain. Use to rotate a secret on Mac (kept consistent in both stores in one shot)."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -256,8 +269,9 @@ def main [name?: string] {
 # Pull all NodeWarden items → update keychain (idempotent). Run after
 # rotating a secret on iPhone or web vault.
 ["bw:sync"]
+extends = "bw:_base"
 description = "Pull all NodeWarden items → update keychain (idempotent). Run after rotating a secret on iPhone or web vault. Skip list: BW_CLIENTID/BW_CLIENTSECRET/BW_SESSION (override via BW_SYNC_SKIP)."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -335,8 +349,9 @@ def main [--dry-run] {
 # ── bw:sync-dry ──────────────────────────────────────────────────────────────
 # Dry-run wrapper for bw:sync.
 ["bw:sync-dry"]
+extends = "bw:_base"
 description = "DRY RUN of bw:sync (preview, no changes)."
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -349,8 +364,9 @@ def main [] {
 # Push every keychain-backed fnox secret → matching NodeWarden item.
 # Idempotent. Skips BW_* (chicken/egg).
 ["bw:migrate-from-keychain"]
+extends = "bw:_base"
 description = "Push every keychain-backed fnox secret → matching NodeWarden item. Idempotent. Skips BW_* (chicken/egg). Override skip list via BW_MIGRATE_SKIP env var (comma-separated)."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -491,8 +507,9 @@ def main [--dry-run] {
 # ── bw:migrate-from-keychain-dry ────────────────────────────────────────────
 # Dry-run wrapper for bw:migrate-from-keychain.
 ["bw:migrate-from-keychain-dry"]
+extends = "bw:_base"
 description = "DRY RUN of bw:migrate-from-keychain (preview, no changes)."
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -508,8 +525,9 @@ def main [] {
 # creds in OS keychain via fnox, registers bitwarden provider in fnox
 # global config. Idempotent — re-run to refresh BW_SESSION.
 ["bw:bootstrap"]
+extends = "bw:_base"
 description = "One-shot Bitwarden CLI ↔ fnox bootstrap. Three hidden prompts (client_id, client_secret, master password). Configures bw against NODEWARDEN_URL, logs in via API key, unlocks vault, stores all three creds in OS keychain via fnox, registers bitwarden provider in fnox global config. Idempotent — re-run to refresh BW_SESSION."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:@bitwarden/cli" = "latest" }
+
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/cf.toml
+++ b/tasks/cf.toml
@@ -11,16 +11,27 @@
 #   ]
 #
 # Tool-pin policy:
-#   - All cf:* tasks need nu (script lang) + fnox (CF token from keychain)
-#   - Tasks calling ^wrangler add "npm:wrangler" = "4"
+#   - cf:_base provides nu + fnox to every cf:* task (`extends` merges tools)
+#   - Tasks calling ^wrangler add "npm:wrangler" = "4" on top via their own tools
 #   - Tasks calling ^curl rely on system curl (present on all 3 OS GHA runners)
+#
+# Consumer requirement: `[settings].experimental = true` in mise.toml — `extends`
+# is mise's experimental task-inheritance feature. See discussion #9637.
+
+# ── cf:_base ─────────────────────────────────────────────────────────────────
+# Hidden base task — every cf:* task extends this for the common nu + fnox
+# pin. Tasks calling ^wrangler add it via their own `tools = { ... }` block,
+# which mise MERGES with the base's tools at runtime.
+["cf:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 
 # ── cf:token-check ───────────────────────────────────────────────────────────
 # Verify CLOUDFLARE_API_TOKEN is valid via /user/tokens/verify. Used as a
 # precondition gate by deploy/prove tasks.
 ["cf:token-check"]
+extends = "cf:_base"
 description = "verify CLOUDFLARE_API_TOKEN is valid — reads from env or fnox"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -60,8 +71,9 @@ def main [] {
 # ── cf:d1-migrate ────────────────────────────────────────────────────────────
 # Apply D1 migrations via wrangler. Pass-through wrapper.
 ["cf:d1-migrate"]
+extends = "cf:_base"
 description = "run D1 migrations"
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -75,8 +87,9 @@ def main [...args] {
 # (comma-separated) from config/<env>.env. Idempotent — skips queues
 # that already exist. No-op when QUEUE_NAMES is empty/unset.
 ["cf:provision-queues"]
+extends = "cf:_base"
 description = "Provision Cloudflare Queues for the active env. Reads QUEUE_NAMES (comma-separated) from config/<env>.env. Idempotent. No-op if QUEUE_NAMES is empty or unset."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -134,8 +147,9 @@ def main [] {
 # canonical fnox names → Worker env var names. Reads APP_POLICY_AUD_FNOX_KEY
 # from config/<env>.env (e.g. D1_MANAGER_POLICY_AUD).
 ["cf:secrets-put-mapped"]
+extends = "cf:_base"
 description = "Push 4 CF Access + auth secrets from fnox to the deployed Worker, mapping canonical fnox names -> Worker env names. Reads APP_POLICY_AUD_FNOX_KEY from config/<env>.env (e.g. D1_MANAGER_POLICY_AUD). Depends on wrangler.toml existing — run wrangler:gen first if needed."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -193,8 +207,9 @@ def main [] {
 # Writes the new D1 id back to the env file. Idempotent — skips create when
 # the named resource already exists.
 ["cf:provision-d1-r2"]
+extends = "cf:_base"
 description = "Provision Cloudflare D1 + R2 for the active env. Reads METADATA_DB_NAME, BACKUP_BUCKET_NAME from config/<env>.env. Either may be empty (skipped). Writes new METADATA_DB_ID back. Idempotent. Skips create when name already present."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -283,8 +298,8 @@ def main [] {
 # from config/<env>.env. Uses the app-level revoke_tokens endpoint (works
 # with the same scope cf:access-setup needs).
 ["cf:access-revoke"]
+extends = "cf:_base"
 description = "Revoke ALL active CF Access sessions for the Worker (kicks everyone out — they can re-login if still on the allowlist). Reads WORKER_NAME + CF_SUBDOMAIN from config/<env>.env. Requires CLOUDFLARE_API_TOKEN with Access: Apps and Policies: Edit (same scope as cf:access-setup)."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -349,8 +364,8 @@ def main [] {
 # (immediately invalidates all uses), removes the policy include, and
 # clears CLOUDFLARE_ACCESS_CLIENT_ID/SECRET from fnox. Idempotent.
 ["cf:service-token-revoke"]
+extends = "cf:_base"
 description = "Revoke this Worker's CF Access service token: deletes the token at CF (immediately invalidates all uses), removes its 'Include' rule from the operator-only policy, and clears CLOUDFLARE_ACCESS_CLIENT_ID/SECRET from fnox. Idempotent — safe to run when nothing exists. Reads WORKER_NAME from config/<env>.env."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -475,8 +490,8 @@ def main [] {
 # Stores CLOUDFLARE_ACCESS_CLIENT_ID/SECRET in fnox so wrangler dev with
 # remote bindings, Playwright, etc. authenticate non-interactively.
 ["cf:service-token-setup"]
+extends = "cf:_base"
 description = "One-shot CF Access service token setup: ensure a per-Worker service token exists and is allowed by the app's operator-only policy. Stores CLOUDFLARE_ACCESS_CLIENT_ID + _SECRET in fnox so wrangler/vite-plugin/Playwright can authenticate non-interactively. Idempotent. Requires CLOUDFLARE_API_TOKEN with Access:Edit. Run cf:access-setup first."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -656,8 +671,8 @@ def main [] {
 # exist; write TEAM_DOMAIN + the per-app POLICY_AUD to fnox. Auto-revokes
 # sessions for emails dropped from OPERATOR_EMAIL. Idempotent.
 ["cf:access-setup"]
+extends = "cf:_base"
 description = "One-shot CF Access setup: ensure GitHub IdP + Access App for this Worker exist; write TEAM_DOMAIN + the per-app POLICY_AUD to fnox. Auto-revokes sessions for emails dropped from OPERATOR_EMAIL. Idempotent. Requires CLOUDFLARE_API_TOKEN with Access:Edit + Access:Organizations:Read + Account.Settings:Read."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -15,6 +15,12 @@
 # Tool pin policy: track the same versions as joeblew999/.github's own
 # mise.toml [tools] block. Bump them together when the lib version is bumped.
 
+# ── ci:_base ──
+# Hidden base task — every ci:* extends this for shared nu pin.
+["ci:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── ci:check-toml-tasks ──────────────────────────────────────────────────────
 # Parse-check every inline `run = '''...'''` body in tasks/*.toml of the
 # current repo. Spawns `nu --ide-check 1` on each extracted body — same
@@ -27,8 +33,9 @@
 # Use as a local pre-push lint AND in CI. Self-hosted: this very task
 # parse-checks itself when run against joeblew999/.github's own tasks/.
 ["ci:check-toml-tasks"]
+extends = "ci:_base"
 description = "Parse-check every inline `run = '''...'''` body in tasks/*.toml via `nu --ide-check`"
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -112,8 +119,9 @@ def main [
 # block and ships it without ever running nu against it locally — leading
 # to a CI failure that takes 60-90s per iteration to feedback.
 ["ci:check-workflow-nu"]
+extends = "ci:_base"
 description = "Parse-check every embedded nu block in .github/workflows/*.yml via `nu --ide-check`"
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -207,8 +215,9 @@ def main [
 # `nu --ide-check 1` on each. Used by every consumer's local `check` bundle
 # as the cheap first-line-of-defense lint.
 ["ci:parse-check"]
+extends = "ci:_base"
 description = "Parse-check every nu task file in mise-tasks/ (fails if any has a syntax error)"
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -260,8 +269,9 @@ def main [
 # REPO is auto-derived from `git remote get-url origin`; works in any repo.
 # Token from GH_TOKEN/GITHUB_TOKEN env or `fnox get GITHUB_TOKEN`.
 ["ci:watch"]
+extends = "ci:_base"
 description = "Watch the latest CI run on this branch — streams per-job + per-step transitions, dumps failed-step logs via gh api"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+tools = { "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
 run = '''
 #!/usr/bin/env nu
 
@@ -464,8 +474,9 @@ def main [
 # Delete CI runs (default: failed/cancelled only; --all to nuke every run;
 # --dry-run to preview). REPO from origin remote; token from env/fnox.
 ["ci:clean"]
+extends = "ci:_base"
 description = "Delete CI runs (default: failed/cancelled only; --all to nuke every run; --dry-run to preview)"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+tools = { "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/mobile.toml
+++ b/tasks/mobile.toml
@@ -13,6 +13,13 @@
 #
 # See tasks/ci.toml header for the broader context + cross-OS canary.
 
+# ── mobile:_base ──
+# Hidden base task — every mobile:* extends this for shared nu pin.
+# Per-task tools add platform stack (java, ruby+cocoapods, tauri-cli).
+["mobile:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── mobile:android-setup ─────────────────────────────────────────────────────
 # One-shot Android toolchain assertion. Verifies Java 17+, ANDROID_HOME,
 # and Android NDK; auto-detects ANDROID_HOME from common Android Studio
@@ -24,8 +31,9 @@
 # mise.toml (every joeblew999 Rust project does); this task just adds
 # Android targets to whatever rust the consumer has.
 ["mobile:android-setup"]
+extends = "mobile:_base"
 description = "Assert Android toolchain: Java 17+, ANDROID_HOME, NDK. Run once per machine."
-tools = { "github:nushell/nushell" = "0.112", java = "temurin-17.0.18+8" }
+tools = { java = "temurin-17.0.18+8" }
 run = '''
 #!/usr/bin/env nu
 
@@ -108,8 +116,9 @@ def main [] {
 # Pinning cocoapods at "latest" matches the long-standing user-global
 # convention and avoids version drift between machines.
 ["mobile:ios-setup"]
+extends = "mobile:_base"
 description = "Assert iOS toolchain: macOS + Xcode CLI tools + CocoaPods. Run once per machine."
-tools = { "github:nushell/nushell" = "0.112", ruby = "3.3", cocoapods = "latest" }
+tools = { ruby = "3.3", cocoapods = "latest" }
 run = '''
 #!/usr/bin/env nu
 
@@ -157,8 +166,9 @@ def main [] {
 # ── mobile:tauri-android-init ────────────────────────────────────────────────
 # Generate the Android project. Run once per clone of a Tauri app.
 ["mobile:tauri-android-init"]
+extends = "mobile:_base"
 description = "tauri android init — generate the Android project (run once per clone)"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
+tools = { "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
 run = '''
 #!/usr/bin/env nu
 
@@ -171,8 +181,9 @@ def main [...args] {
 # ── mobile:tauri-android-dev ─────────────────────────────────────────────────
 # Hot-reload Tauri Android dev build on a connected device or emulator.
 ["mobile:tauri-android-dev"]
+extends = "mobile:_base"
 description = "tauri android dev — hot-reload on connected device or emulator"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
+tools = { "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
 run = '''
 #!/usr/bin/env nu
 
@@ -185,8 +196,9 @@ def main [...args] {
 # ── mobile:tauri-android-build ───────────────────────────────────────────────
 # Release Tauri Android APK/AAB build.
 ["mobile:tauri-android-build"]
+extends = "mobile:_base"
 description = "tauri android build — release APK/AAB"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
+tools = { "cargo:tauri-cli" = "2", java = "temurin-17.0.18+8" }
 run = '''
 #!/usr/bin/env nu
 
@@ -199,8 +211,9 @@ def main [...args] {
 # ── mobile:tauri-ios-init ────────────────────────────────────────────────────
 # Generate the Xcode project. macOS-only.
 ["mobile:tauri-ios-init"]
+extends = "mobile:_base"
 description = "tauri ios init — generate the Xcode project (macOS only, run once per clone)"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
+tools = { "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
 run = '''
 #!/usr/bin/env nu
 
@@ -217,8 +230,9 @@ def main [...args] {
 # ── mobile:tauri-ios-dev ─────────────────────────────────────────────────────
 # Hot-reload Tauri iOS on connected device or simulator. macOS-only.
 ["mobile:tauri-ios-dev"]
+extends = "mobile:_base"
 description = "tauri ios dev — hot-reload on connected device or simulator (macOS only)"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
+tools = { "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
 run = '''
 #!/usr/bin/env nu
 
@@ -235,8 +249,9 @@ def main [...args] {
 # ── mobile:tauri-ios-build ───────────────────────────────────────────────────
 # Release Tauri IPA build. macOS-only.
 ["mobile:tauri-ios-build"]
+extends = "mobile:_base"
 description = "tauri ios build — release IPA (macOS only)"
-tools = { "github:nushell/nushell" = "0.112", "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
+tools = { "cargo:tauri-cli" = "2", ruby = "3.3", cocoapods = "latest" }
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/prove.toml
+++ b/tasks/prove.toml
@@ -11,13 +11,20 @@
 #     "git::https://github.com/joeblew999/.github.git//tasks/prove.toml?ref=v0.17.2",
 #   ]
 
+# ── prove:_base ──
+# Hidden base task — every prove:* extends this for shared nu pin.
+["prove:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── prove:bindings ───────────────────────────────────────────────────────────
 # Confirm the deployed Worker's bindings via wrangler --dry-run (no upload).
 # Catches drift between wrangler.toml.template and the resources actually
 # created.
 ["prove:bindings"]
+extends = "prove:_base"
 description = "Confirm the deployed Worker's bindings via wrangler --dry-run (no upload). Catches drift between wrangler.toml.template and the resources actually created."
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -37,8 +44,9 @@ def main [] {
 # List secrets on the deployed Worker, assert all 4 expected names are
 # present (ACCOUNT_ID, API_KEY, TEAM_DOMAIN, POLICY_AUD).
 ["prove:secrets"]
+extends = "prove:_base"
 description = "List secrets on the deployed Worker, assert all 4 expected names present (ACCOUNT_ID, API_KEY, TEAM_DOMAIN, POLICY_AUD)."
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -62,8 +70,9 @@ def main [] {
 # Smoke-test the deployed Worker — expect 302 to CF Access challenge with
 # the AUD stored in fnox under APP_POLICY_AUD_FNOX_KEY.
 ["prove:deployed"]
+extends = "prove:_base"
 description = "Smoke-test the deployed Worker — expect 302 to CF Access challenge with the AUD stored in fnox under APP_POLICY_AUD_FNOX_KEY."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+tools = { "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -131,8 +140,9 @@ def main [] {
 # Verify the CF Access App for this Worker has at least one allow policy.
 # Without one, login 403s after OAuth.
 ["prove:access-policy"]
+extends = "prove:_base"
 description = "Verify the CF Access App for this Worker has at least one allow policy. Without one, login 403s after OAuth."
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+tools = { "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/rust.toml
+++ b/tasks/rust.toml
@@ -10,11 +10,18 @@
 #     "git::https://github.com/joeblew999/.github.git//tasks/rust.toml?ref=v0.17.4",
 #   ]
 
+# ── rust:_base ──
+# Hidden base task — every rust:* extends this for shared nu pin.
+["rust:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── rust:build ───────────────────────────────────────────────────────────────
 # cargo build --all-targets, with RUST_BACKTRACE=1 for better diagnostics.
 ["rust:build"]
+extends = "rust:_base"
 description = "cargo build (all targets)"
-tools = { "github:nushell/nushell" = "0.112" }
+
 env = { RUST_BACKTRACE = "1" }
 run = '''
 #!/usr/bin/env nu
@@ -27,8 +34,9 @@ def main [...args] {
 # ── rust:test ────────────────────────────────────────────────────────────────
 # cargo test --all-targets.
 ["rust:test"]
+extends = "rust:_base"
 description = "cargo test (all targets)"
-tools = { "github:nushell/nushell" = "0.112" }
+
 env = { RUST_BACKTRACE = "1" }
 run = '''
 #!/usr/bin/env nu
@@ -42,8 +50,9 @@ def main [...args] {
 # Compile a Rust crate to WASM via wasm-pack. Pins wasm-pack per-task
 # (consumers don't have to install it globally).
 ["rust:wasm-pack"]
+extends = "rust:_base"
 description = "compile a Rust crate to WASM via wasm-pack"
-tools = { "github:nushell/nushell" = "0.112", "cargo:wasm-pack" = "latest" }
+tools = { "cargo:wasm-pack" = "latest" }
 usage = '''
 arg "<crate-dir>" help="path to the crate directory to compile"
 '''

--- a/tasks/secrets.toml
+++ b/tasks/secrets.toml
@@ -6,12 +6,19 @@
 # Push secrets from fnox → current repo's GitHub Actions secrets. Reads
 # FNOX_SYNC_KEYS from the consumer's mise.toml [env] (comma-separated).
 # Each named key is pulled from fnox and pushed via `gh secret set`.
+# ── secrets:_base ──
+# Hidden base task — every secrets:* extends this for shared nu pin.
+["secrets:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── secrets:status ───────────────────────────────────────────────────────────
 # Show fnox-stored secrets + the current repo's GitHub Actions secrets
 # side-by-side. Useful for spot-checking what's where before/after a sync.
 ["secrets:status"]
+extends = "secrets:_base"
 description = "show fnox secrets + current repo's GitHub Actions secrets"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+tools = { "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
 run = '''
 #!/usr/bin/env nu
 
@@ -53,8 +60,9 @@ def main [] {
 # Idempotent — adds the keychain provider if not already configured, then
 # walks every age-encrypted secret and re-stores it under keychain.
 ["secrets:migrate-to-keychain"]
+extends = "secrets:_base"
 description = "move every age-encrypted secret in fnox global config → OS keychain"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24" }
+tools = { "github:jdx/fnox" = "1.24" }
 run = '''
 #!/usr/bin/env nu
 
@@ -113,8 +121,9 @@ def main [] {
 # via `path self`-relative invocation; in TOML form we pass-through via
 # `mise run`.
 ["secrets:sync-github-dry"]
+extends = "secrets:_base"
 description = "dry-run of secrets:sync-github (show plan, change nothing)"
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -125,8 +134,9 @@ def main [] {
 
 # ── secrets:sync-github ──────────────────────────────────────────────────────
 ["secrets:sync-github"]
+extends = "secrets:_base"
 description = "push secrets from fnox → current repo's GitHub Actions secrets"
-tools = { "github:nushell/nushell" = "0.112", "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
+tools = { "github:jdx/fnox" = "1.24", "aqua:cli/cli" = "2" }
 run = '''
 #!/usr/bin/env nu
 

--- a/tasks/wrangler.toml
+++ b/tasks/wrangler.toml
@@ -13,11 +13,18 @@
 # All wrangler:* tasks pin npm:wrangler per-task; consumers don't have to
 # pin wrangler globally just because a deploy/dev/tail task uses it.
 
+# ── wrangler:_base ──
+# Hidden base task — every wrangler:* extends this for shared nu pin.
+["wrangler:_base"]
+hide = true
+tools = { "github:nushell/nushell" = "0.112" }
+
 # ── wrangler:deploy ──────────────────────────────────────────────────────────
 # Pass-through to `wrangler deploy`. Forwards all args verbatim.
 ["wrangler:deploy"]
+extends = "wrangler:_base"
 description = "deploy to Cloudflare Workers"
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -29,8 +36,9 @@ def main [...args] {
 # ── wrangler:dev ─────────────────────────────────────────────────────────────
 # Pass-through to `wrangler dev` for local multi-worker development.
 ["wrangler:dev"]
+extends = "wrangler:_base"
 description = "wrangler local dev (multi-worker)"
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 run = '''
 #!/usr/bin/env nu
 
@@ -47,8 +55,9 @@ def main [...args] {
 # Note: this task does NOT call wrangler — it's pure nu template
 # substitution. So no npm:wrangler in tools.
 ["wrangler:gen"]
+extends = "wrangler:_base"
 description = "Generate wrangler.{toml,jsonc} from wrangler.{toml,jsonc}.template + config/<env>.env via nushell template substitution. Auto-detects which template format the fork uses. Per-fork values are interpolated; the result is gitignored."
-tools = { "github:nushell/nushell" = "0.112" }
+
 run = '''
 #!/usr/bin/env nu
 
@@ -97,8 +106,9 @@ def main [] {
 # ── wrangler:secret-list ─────────────────────────────────────────────────────
 # List secrets set on a deployed Worker (values hidden).
 ["wrangler:secret-list"]
+extends = "wrangler:_base"
 description = "list secrets set on a deployed Worker (values hidden)"
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 usage = '''
 flag "--env <env>" help="Cloudflare environment" default="production"
 '''
@@ -116,8 +126,9 @@ def main [...args] {
 # Tail live logs from a deployed Worker. Defaults to production env;
 # pass --env <env> for staging/preview.
 ["wrangler:tail"]
+extends = "wrangler:_base"
 description = "tail live logs from a deployed Worker"
-tools = { "github:nushell/nushell" = "0.112", "npm:wrangler" = "4" }
+tools = { "npm:wrangler" = "4" }
 usage = '''
 flag "--env <env>" help="Cloudflare environment to tail" default="production"
 '''


### PR DESCRIPTION
Eight namespaces refactored to use mise's experimental `extends` for per-task tool dedup. Each tasks/<ns>.toml gets a hidden <ns>:_base; child tasks extend and add only their deltas.

| File | Base tools | Children |
|---|---|---|
| cf.toml | nu, fnox | 9 |
| bw.toml | nu, fnox, bw | 10 |
| ci.toml | nu | 5 |
| mobile.toml | nu | 8 |
| prove.toml | nu | 4 |
| rust.toml | nu | 3 |
| secrets.toml | nu | 4 |
| wrangler.toml | nu | 5 |

Consumer requirement: `[settings].experimental = true`.

Pre-flight verified: extends works through git:: remote includes (test-extends fixture, since deleted).

Verified locally:
- 50 visible tasks (8 _base hidden)  
- 52 inline run bodies parse-clean via ci:check-toml-tasks
- cf:token-check actually invokes ^fnox at runtime — proves merge is at runtime, not just parse time