### PR TITLE
fix(v0.19): Gemini Code Assist feedback bundle + lib self-hosting

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,30 @@
+[settings]
+# extends task-inheritance is mise experimental — joeblew999/.github
+# v0.18+ uses it for per-namespace tools dedup (cf:_base, bw:_base, etc).
+experimental = true
+
 [task_config]
-includes = ["mise-tasks"]
+# Self-hosting: include every tasks/*.toml file so the lib can run its
+# own ci:check-toml-tasks etc. against itself. mise doesn't auto-discover
+# tasks/ (only mise-tasks/, mise/tasks/, .mise/tasks/), so list explicitly.
+#
+# mise-tasks/ is kept (auto-discovered) for the legacy file-tasks
+# release + _proof until those are also ported (release stays for
+# maintainer use; _proof is referenced by mise-tasks-lint.yml).
+includes = [
+  "mise-tasks",
+  "tasks/bw.toml",
+  "tasks/cf.toml",
+  "tasks/ci.toml",
+  "tasks/env.toml",
+  "tasks/fnox.toml",
+  "tasks/mise.toml",
+  "tasks/mobile.toml",
+  "tasks/prove.toml",
+  "tasks/rust.toml",
+  "tasks/secrets.toml",
+  "tasks/wrangler.toml",
+]
 
 [tools]
 "github:jdx/fnox"        = "1.24"
@@ -7,5 +32,3 @@ includes = ["mise-tasks"]
 "aqua:cli/cli"           = "2"
 "aqua:jqlang/jq"         = "1"
 "cargo:usage-cli"        = "3"
-# utm-dev Rust CLI — add once utm-dev is rewritten as a Rust binary:
-# "cargo:utm-dev" = "3"

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -68,27 +68,41 @@ def main [
   if ($work | path exists) { rm -rf $work }
   mkdir $work
 
-  # Pattern: quoted top-level key (namespace:task) + `run = '<TQ>...<TQ>'`.
-  # Triple-single-quote (<TQ>) built from \u{27} so this script's body
-  # can itself be wrapped in a TOML `run = '<TQ>...<TQ>'` block without
-  # the inner closing the outer.
-  let q3 = (['\u{27}', '\u{27}', '\u{27}'] | str join)
-  let pattern = ("(?s)\\[\"([^\"]+)\"\\][^\\[]*?run\\s*=\\s*" + $q3 + "(.*?)" + $q3)
+  # Patterns: handle BOTH triple-single AND triple-double quoted run bodies.
+  # TOML allows both forms; previously only single-quote (TQS) was matched.
+  # Triple-quote markers built from char codes (\u{27}=apostrophe,
+  # \u{22}=quote) so this script's own body can be wrapped in a TOML
+  # triple-quoted block without the inner triples closing the outer.
+  let q3s = (['\u{27}', '\u{27}', '\u{27}'] | str join)
+  let q3d = (['\u{22}', '\u{22}', '\u{22}'] | str join)
+  let pat_single = ("(?s)\\[\"([^\"]+)\"\\][^\\[]*?run\\s*=\\s*" + $q3s + "(.*?)" + $q3s)
+  let pat_double = ("(?s)\\[\"([^\"]+)\"\\][^\\[]*?run\\s*=\\s*" + $q3d + "(.*?)" + $q3d)
 
   mut total = 0
   mut failed = []
 
   for t in $tomls {
     let raw = (open --raw $t)
-    let bodies = ($raw | parse --regex $pattern | rename task body)
+    let bodies = (
+      ($raw | parse --regex $pat_single | rename task body)
+      | append ($raw | parse --regex $pat_double | rename task body)
+    )
     for entry in $bodies {
       $total = $total + 1
       let safe = ($entry.task | str replace --all ":" "_")
       let tmp = ($work | path join $"($safe).nu")
       $entry.body | save --force $tmp
       let r = (do { ^nu --ide-check 1 $tmp } | complete)
-      if ($r.stdout | str contains "severity\":\"Error") {
-        let first_diag = ($r.stdout | lines | first | default "")
+      # Strict diagnostic match: require BOTH `"type":"diagnostic"` AND
+      # `"severity":"Error"` on the same line (not just a stray "Error"
+      # appearing somewhere in stdout).
+      let err_lines = (
+        $r.stdout
+        | lines
+        | where { |l| ($l | str contains "\"type\":\"diagnostic\"") and ($l | str contains "\"severity\":\"Error\"") }
+      )
+      if ($err_lines | length) > 0 {
+        let first_diag = ($err_lines | first | default "")
         $failed = ($failed | append {task: $entry.task, error: $first_diag})
       }
     }

--- a/tasks/rust.toml
+++ b/tasks/rust.toml
@@ -52,7 +52,7 @@ def main [...args] {
 ["rust:wasm-pack"]
 extends = "rust:_base"
 description = "compile a Rust crate to WASM via wasm-pack"
-tools = { "cargo:wasm-pack" = "latest" }
+tools = { "cargo:wasm-pack" = "0.13" }
 usage = '''
 arg "<crate-dir>" help="path to the crate directory to compile"
 '''

--- a/tasks/secrets.toml
+++ b/tasks/secrets.toml
@@ -2,12 +2,10 @@
 #
 # See tasks/ci.toml for the consumer wiring + tool pin policy.
 
-# ── secrets:sync-github ──────────────────────────────────────────────────────
-# Push secrets from fnox → current repo's GitHub Actions secrets. Reads
-# FNOX_SYNC_KEYS from the consumer's mise.toml [env] (comma-separated).
-# Each named key is pulled from fnox and pushed via `gh secret set`.
-# ── secrets:_base ──
-# Hidden base task — every secrets:* extends this for shared nu pin.
+# ── secrets:_base ────────────────────────────────────────────────────────────
+# Hidden base task — every secrets:* extends this for the common nu pin.
+# Tasks add fnox / gh as needed via their own `tools = { ... }` block;
+# mise MERGES with the base's tools at runtime.
 ["secrets:_base"]
 hide = true
 tools = { "github:nushell/nushell" = "0.112" }


### PR DESCRIPTION
Bundles Gemini Code Assist findings from PRs #44/#45/#46 + makes `.github` self-host on tasks/*.toml.

## Gemini fixes
- **#44**: Pin cargo:wasm-pack `0.13` (was `latest`)
- **#45**: ci:check-toml-tasks now handles `'''` AND `"""` bodies; tighter diagnostic filter (require both type:diagnostic + severity:Error)
- **#46**: Move secrets:_base to top of file; add `experimental = true` to .github/mise.toml

## Self-hosting
`.github/mise.toml` now explicitly includes every `tasks/*.toml` so the lib can `mise run ci:check-toml-tasks` against itself. mise-tasks/ kept for legacy release + _proof.

## Test plan

- [x] 52 inline run bodies parse-clean
- [x] 29 embedded workflow nu blocks parse-clean
- [x] Negative tests catch broken nu in BOTH quoting styles
- [x] Lib's own `mise tasks ls` succeeds (extends merge works)
- [ ] tasks-toml-proof on linux+macos+windows